### PR TITLE
Make google submodule shallow

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "tests/proto/googleapis"]
 	path = tests/proto/googleapis
 	url = https://github.com/googleapis/googleapis.git
+	shallow = true


### PR DESCRIPTION
On slow connections it takes a very long time to fetch whole submodule;
Hopefully making it shallow will help in such case
![image](https://github.com/blockscout/actix-prost/assets/8144358/cfd723b8-a5cc-4fff-8892-63473b3a997d)
