### PR TITLE
fix: make 'one of' inside message use a snake_case

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,12 @@
 [workspace]
-members = ["actix-prost", "actix-prost-build", "actix-prost-macros", "convert-trait", "tests"]
+resolver = "1"
+members = [
+    "actix-prost",
+    "actix-prost-build",
+    "actix-prost-macros",
+    "convert-trait",
+    "tests"
+]
 
 # We need the master branch, because https://github.com/tokio-rs/prost/pull/714 isn't published yet
 [patch.crates-io]

--- a/actix-prost-macros/src/enums.rs
+++ b/actix-prost-macros/src/enums.rs
@@ -5,7 +5,7 @@ enum Kind {
     OneOf,
 }
 
-pub fn process_enum(item: &mut syn::ItemEnum) -> Option<TokenStream> {
+pub fn process_enum(item: &mut syn::ItemEnum, maybe_rename: Option<String>) -> Option<TokenStream> {
     let derive = item
         .attrs
         .iter()
@@ -43,8 +43,10 @@ pub fn process_enum(item: &mut syn::ItemEnum) -> Option<TokenStream> {
     };
     match kind {
         Kind::OneOf => {
-            item.attrs
-                .push(syn::parse_quote!(#[serde(rename_all="camelCase")]));
+            if let Some(rename) = maybe_rename {
+                item.attrs
+                    .push(syn::parse_quote!(#[serde(rename_all=#rename)]));
+            }
             None
         }
         Kind::Enum => {

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -24,7 +24,13 @@ fn compile(
         .protoc_arg("--openapiv2_out=proto")
         .protoc_arg("--openapiv2_opt")
         .protoc_arg("grpc_api_configuration=proto/http_api.yaml,output_format=yaml")
-        .type_attribute(".", "#[actix_prost_macros::serde]");
+        .type_attribute(".errors", "#[actix_prost_macros::serde]")
+        .type_attribute(".rest", "#[actix_prost_macros::serde]")
+        .type_attribute(".types", "#[actix_prost_macros::serde]")
+        .type_attribute(
+            ".snake_case_types",
+            "#[actix_prost_macros::serde(rename_all=\"snake_case\")]",
+        );
 
     config.compile_protos(protos, includes)?;
     Ok(())
@@ -42,6 +48,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "proto/types.proto",
             "proto/errors.proto",
             "proto/conversions.proto",
+            "proto/snake_case_types.proto",
         ],
         &["proto/", "proto/googleapis", "proto/grpc-gateway"],
         gens,

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -24,8 +24,10 @@ fn compile(
         .protoc_arg("--openapiv2_out=proto")
         .protoc_arg("--openapiv2_opt")
         .protoc_arg("grpc_api_configuration=proto/http_api.yaml,output_format=yaml")
+        .type_attribute(".conversions", "#[actix_prost_macros::serde]")
         .type_attribute(".errors", "#[actix_prost_macros::serde]")
         .type_attribute(".rest", "#[actix_prost_macros::serde]")
+        .type_attribute(".simple", "#[actix_prost_macros::serde]")
         .type_attribute(".types", "#[actix_prost_macros::serde]")
         .type_attribute(
             ".snake_case_types",

--- a/tests/proto/errors.swagger.yaml
+++ b/tests/proto/errors.swagger.yaml
@@ -1,0 +1,177 @@
+swagger: "2.0"
+info:
+  title: errors.proto
+  version: version not set
+tags:
+  - name: ErrorsRPC
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /errors/{code}:
+    post:
+      operationId: ErrorsRPC_Error
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/errorsErrorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: code
+          in: path
+          required: true
+          type: integer
+          format: int32
+        - name: message
+          in: body
+          required: true
+          schema:
+            type: string
+        - name: query
+          in: query
+          required: false
+          type: string
+      tags:
+        - ErrorsRPC
+definitions:
+  errorsErrorResponse:
+    type: object
+  protobufAny:
+    type: object
+    properties:
+      '@type':
+        type: string
+        description: |-
+          A URL/resource name that uniquely identifies the type of the serialized
+          protocol buffer message. This string must contain at least
+          one "/" character. The last segment of the URL's path must represent
+          the fully qualified name of the type (as in
+          `path/google.protobuf.Duration`). The name should be in a canonical form
+          (e.g., leading "." is not accepted).
+
+          In practice, teams usually precompile into the binary all types that they
+          expect it to use in the context of Any. However, for URLs which use the
+          scheme `http`, `https`, or no scheme, one can optionally set up a type
+          server that maps type URLs to message definitions as follows:
+
+          * If no scheme is provided, `https` is assumed.
+          * An HTTP GET on the URL must yield a [google.protobuf.Type][]
+            value in binary format, or produce an error.
+          * Applications are allowed to cache lookup results based on the
+            URL, or have them precompiled into a binary to avoid any
+            lookup. Therefore, binary compatibility needs to be preserved
+            on changes to types. (Use versioned type names to manage
+            breaking changes.)
+
+          Note: this functionality is not currently available in the official
+          protobuf release, and it is not used for type URLs beginning with
+          type.googleapis.com. As of May 2023, there are no widely used type server
+          implementations and no plans to implement one.
+
+          Schemes other than `http`, `https` (or the empty scheme) might be
+          used with implementation specific semantics.
+    additionalProperties: {}
+    description: |-
+      `Any` contains an arbitrary serialized protocol buffer message along with a
+      URL that describes the type of the serialized message.
+
+      Protobuf library provides support to pack/unpack Any values in the form
+      of utility functions or additional generated methods of the Any type.
+
+      Example 1: Pack and unpack a message in C++.
+
+          Foo foo = ...;
+          Any any;
+          any.PackFrom(foo);
+          ...
+          if (any.UnpackTo(&foo)) {
+            ...
+          }
+
+      Example 2: Pack and unpack a message in Java.
+
+          Foo foo = ...;
+          Any any = Any.pack(foo);
+          ...
+          if (any.is(Foo.class)) {
+            foo = any.unpack(Foo.class);
+          }
+          // or ...
+          if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+            foo = any.unpack(Foo.getDefaultInstance());
+          }
+
+       Example 3: Pack and unpack a message in Python.
+
+          foo = Foo(...)
+          any = Any()
+          any.Pack(foo)
+          ...
+          if any.Is(Foo.DESCRIPTOR):
+            any.Unpack(foo)
+            ...
+
+       Example 4: Pack and unpack a message in Go
+
+           foo := &pb.Foo{...}
+           any, err := anypb.New(foo)
+           if err != nil {
+             ...
+           }
+           ...
+           foo := &pb.Foo{}
+           if err := any.UnmarshalTo(foo); err != nil {
+             ...
+           }
+
+      The pack methods provided by protobuf library will by default use
+      'type.googleapis.com/full.type.name' as the type URL and the unpack
+      methods only use the fully qualified type name after the last '/'
+      in the type URL, for example "foo.bar.com/x/y.z" will yield type
+      name "y.z".
+
+      JSON
+      ====
+      The JSON representation of an `Any` value uses the regular
+      representation of the deserialized, embedded message, with an
+      additional field `@type` which contains the type URL. Example:
+
+          package google.profile;
+          message Person {
+            string first_name = 1;
+            string last_name = 2;
+          }
+
+          {
+            "@type": "type.googleapis.com/google.profile.Person",
+            "firstName": <string>,
+            "lastName": <string>
+          }
+
+      If the embedded message type is well-known and has a custom JSON
+      representation, that representation will be embedded adding a field
+      `value` which holds the custom JSON in addition to the `@type`
+      field. Example (for message [google.protobuf.Duration][]):
+
+          {
+            "@type": "type.googleapis.com/google.protobuf.Duration",
+            "value": "1.212s"
+          }
+  rpcStatus:
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+      details:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/protobufAny'

--- a/tests/proto/http_api.yaml
+++ b/tests/proto/http_api.yaml
@@ -68,3 +68,10 @@ http:
   - selector: "conversions.ConversionsRPC.ConvertRPC"
     post: /conversions
     body: "*"
+
+  - selector: "snake_case_types.SnakeCaseTypesRPC.SimpleMessagesRPC"
+    post: /snake-case-types/simple-messages
+    body: "*"
+  - selector: "snake_case_types.SnakeCaseTypesRPC.OneOfsRPC"
+    post: /snake-case-types/oneofs
+    body: "*"

--- a/tests/proto/rest.swagger.yaml
+++ b/tests/proto/rest.swagger.yaml
@@ -1,0 +1,378 @@
+swagger: "2.0"
+info:
+  title: rest.proto
+  version: version not set
+tags:
+  - name: RestRPC
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /rest/get/{foo}:
+    get:
+      operationId: RestRPC_GetQueryRPC
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/restGet'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: foo
+          in: path
+          required: true
+          type: string
+        - name: bar
+          in: query
+          required: false
+          type: string
+          format: int64
+      tags:
+        - RestRPC
+  /rest/get/{foo}/{bar}:
+    get:
+      operationId: RestRPC_GetRPC
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/restGet'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: foo
+          in: path
+          required: true
+          type: string
+        - name: bar
+          in: path
+          required: true
+          type: string
+          format: int64
+      tags:
+        - RestRPC
+  /rest/post:
+    post:
+      operationId: RestRPC_PostNoPathRPC
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/restPost'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/restPost'
+      tags:
+        - RestRPC
+  /rest/post/{foo}/{bar}:
+    post:
+      operationId: RestRPC_PostRPC
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/restPost'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: foo
+          in: path
+          required: true
+          type: string
+        - name: bar
+          in: path
+          required: true
+          type: string
+          format: int64
+        - name: longName
+          in: body
+          required: true
+          schema:
+            type: number
+            format: double
+      tags:
+        - RestRPC
+  /rest/post/{longName}:
+    post:
+      operationId: RestRPC_PostQueryRPC
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/restPost'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: longName
+          in: path
+          required: true
+          type: number
+          format: double
+        - name: foo
+          in: body
+          required: true
+          schema:
+            type: string
+        - name: bar
+          in: query
+          required: false
+          type: string
+          format: int64
+      tags:
+        - RestRPC
+  /rest/post_get:
+    post:
+      operationId: RestRPC_PostGetRPC
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/restGet'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/restPost'
+      tags:
+        - RestRPC
+  /rest/response/get/{foo}/{bar}:
+    get:
+      operationId: RestRPC_GetResponseRPC
+      responses:
+        "200":
+          description: ""
+          schema:
+            type: string
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: foo
+          in: path
+          required: true
+          type: string
+        - name: bar
+          in: path
+          required: true
+          type: string
+          format: int64
+      tags:
+        - RestRPC
+  /rest/response/post:
+    post:
+      operationId: RestRPC_PostResponseRPC
+      responses:
+        "200":
+          description: ""
+          schema:
+            type: string
+            format: int64
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/restPost'
+      tags:
+        - RestRPC
+  /rest/response/post_get:
+    post:
+      operationId: RestRPC_PostResponseGetRPC
+      responses:
+        "200":
+          description: ""
+          schema:
+            type: string
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/restPost'
+      tags:
+        - RestRPC
+definitions:
+  protobufAny:
+    type: object
+    properties:
+      '@type':
+        type: string
+        description: |-
+          A URL/resource name that uniquely identifies the type of the serialized
+          protocol buffer message. This string must contain at least
+          one "/" character. The last segment of the URL's path must represent
+          the fully qualified name of the type (as in
+          `path/google.protobuf.Duration`). The name should be in a canonical form
+          (e.g., leading "." is not accepted).
+
+          In practice, teams usually precompile into the binary all types that they
+          expect it to use in the context of Any. However, for URLs which use the
+          scheme `http`, `https`, or no scheme, one can optionally set up a type
+          server that maps type URLs to message definitions as follows:
+
+          * If no scheme is provided, `https` is assumed.
+          * An HTTP GET on the URL must yield a [google.protobuf.Type][]
+            value in binary format, or produce an error.
+          * Applications are allowed to cache lookup results based on the
+            URL, or have them precompiled into a binary to avoid any
+            lookup. Therefore, binary compatibility needs to be preserved
+            on changes to types. (Use versioned type names to manage
+            breaking changes.)
+
+          Note: this functionality is not currently available in the official
+          protobuf release, and it is not used for type URLs beginning with
+          type.googleapis.com. As of May 2023, there are no widely used type server
+          implementations and no plans to implement one.
+
+          Schemes other than `http`, `https` (or the empty scheme) might be
+          used with implementation specific semantics.
+    additionalProperties: {}
+    description: |-
+      `Any` contains an arbitrary serialized protocol buffer message along with a
+      URL that describes the type of the serialized message.
+
+      Protobuf library provides support to pack/unpack Any values in the form
+      of utility functions or additional generated methods of the Any type.
+
+      Example 1: Pack and unpack a message in C++.
+
+          Foo foo = ...;
+          Any any;
+          any.PackFrom(foo);
+          ...
+          if (any.UnpackTo(&foo)) {
+            ...
+          }
+
+      Example 2: Pack and unpack a message in Java.
+
+          Foo foo = ...;
+          Any any = Any.pack(foo);
+          ...
+          if (any.is(Foo.class)) {
+            foo = any.unpack(Foo.class);
+          }
+          // or ...
+          if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+            foo = any.unpack(Foo.getDefaultInstance());
+          }
+
+       Example 3: Pack and unpack a message in Python.
+
+          foo = Foo(...)
+          any = Any()
+          any.Pack(foo)
+          ...
+          if any.Is(Foo.DESCRIPTOR):
+            any.Unpack(foo)
+            ...
+
+       Example 4: Pack and unpack a message in Go
+
+           foo := &pb.Foo{...}
+           any, err := anypb.New(foo)
+           if err != nil {
+             ...
+           }
+           ...
+           foo := &pb.Foo{}
+           if err := any.UnmarshalTo(foo); err != nil {
+             ...
+           }
+
+      The pack methods provided by protobuf library will by default use
+      'type.googleapis.com/full.type.name' as the type URL and the unpack
+      methods only use the fully qualified type name after the last '/'
+      in the type URL, for example "foo.bar.com/x/y.z" will yield type
+      name "y.z".
+
+      JSON
+      ====
+      The JSON representation of an `Any` value uses the regular
+      representation of the deserialized, embedded message, with an
+      additional field `@type` which contains the type URL. Example:
+
+          package google.profile;
+          message Person {
+            string first_name = 1;
+            string last_name = 2;
+          }
+
+          {
+            "@type": "type.googleapis.com/google.profile.Person",
+            "firstName": <string>,
+            "lastName": <string>
+          }
+
+      If the embedded message type is well-known and has a custom JSON
+      representation, that representation will be embedded adding a field
+      `value` which holds the custom JSON in addition to the `@type`
+      field. Example (for message [google.protobuf.Duration][]):
+
+          {
+            "@type": "type.googleapis.com/google.protobuf.Duration",
+            "value": "1.212s"
+          }
+  restGet:
+    type: object
+    properties:
+      foo:
+        type: string
+      bar:
+        type: string
+        format: int64
+  restPost:
+    type: object
+    properties:
+      foo:
+        type: string
+      bar:
+        type: string
+        format: int64
+      longName:
+        type: number
+        format: double
+  rpcStatus:
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+      details:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/protobufAny'

--- a/tests/proto/snake_case_types.proto
+++ b/tests/proto/snake_case_types.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+package snake_case_types;
+
+option go_package = "github.com/blockscout/actix-prost/tests";
+
+message SimpleMessages {
+  int64 long_name_field = 1;
+}
+
+message OneOfs {
+  oneof snake_case_values {
+    int64 first_snake_case_value = 1;
+    int64 second_snake_case_value = 2;
+  }
+}
+
+service SnakeCaseTypesRPC {
+  rpc SimpleMessagesRPC(SimpleMessages) returns (SimpleMessages);
+  rpc OneOfsRPC(OneOfs) returns (OneOfs);
+}

--- a/tests/proto/snake_case_types.swagger.yaml
+++ b/tests/proto/snake_case_types.swagger.yaml
@@ -1,0 +1,201 @@
+swagger: "2.0"
+info:
+  title: snake_case_types.proto
+  version: version not set
+tags:
+  - name: SnakeCaseTypesRPC
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /snake-case-types/oneofs:
+    post:
+      operationId: SnakeCaseTypesRPC_OneOfsRPC
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/snake_case_typesOneOfs'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/snake_case_typesOneOfs'
+      tags:
+        - SnakeCaseTypesRPC
+  /snake-case-types/simple-messages:
+    post:
+      operationId: SnakeCaseTypesRPC_SimpleMessagesRPC
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/snake_case_typesSimpleMessages'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/snake_case_typesSimpleMessages'
+      tags:
+        - SnakeCaseTypesRPC
+definitions:
+  protobufAny:
+    type: object
+    properties:
+      '@type':
+        type: string
+        description: |-
+          A URL/resource name that uniquely identifies the type of the serialized
+          protocol buffer message. This string must contain at least
+          one "/" character. The last segment of the URL's path must represent
+          the fully qualified name of the type (as in
+          `path/google.protobuf.Duration`). The name should be in a canonical form
+          (e.g., leading "." is not accepted).
+
+          In practice, teams usually precompile into the binary all types that they
+          expect it to use in the context of Any. However, for URLs which use the
+          scheme `http`, `https`, or no scheme, one can optionally set up a type
+          server that maps type URLs to message definitions as follows:
+
+          * If no scheme is provided, `https` is assumed.
+          * An HTTP GET on the URL must yield a [google.protobuf.Type][]
+            value in binary format, or produce an error.
+          * Applications are allowed to cache lookup results based on the
+            URL, or have them precompiled into a binary to avoid any
+            lookup. Therefore, binary compatibility needs to be preserved
+            on changes to types. (Use versioned type names to manage
+            breaking changes.)
+
+          Note: this functionality is not currently available in the official
+          protobuf release, and it is not used for type URLs beginning with
+          type.googleapis.com. As of May 2023, there are no widely used type server
+          implementations and no plans to implement one.
+
+          Schemes other than `http`, `https` (or the empty scheme) might be
+          used with implementation specific semantics.
+    additionalProperties: {}
+    description: |-
+      `Any` contains an arbitrary serialized protocol buffer message along with a
+      URL that describes the type of the serialized message.
+
+      Protobuf library provides support to pack/unpack Any values in the form
+      of utility functions or additional generated methods of the Any type.
+
+      Example 1: Pack and unpack a message in C++.
+
+          Foo foo = ...;
+          Any any;
+          any.PackFrom(foo);
+          ...
+          if (any.UnpackTo(&foo)) {
+            ...
+          }
+
+      Example 2: Pack and unpack a message in Java.
+
+          Foo foo = ...;
+          Any any = Any.pack(foo);
+          ...
+          if (any.is(Foo.class)) {
+            foo = any.unpack(Foo.class);
+          }
+          // or ...
+          if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+            foo = any.unpack(Foo.getDefaultInstance());
+          }
+
+       Example 3: Pack and unpack a message in Python.
+
+          foo = Foo(...)
+          any = Any()
+          any.Pack(foo)
+          ...
+          if any.Is(Foo.DESCRIPTOR):
+            any.Unpack(foo)
+            ...
+
+       Example 4: Pack and unpack a message in Go
+
+           foo := &pb.Foo{...}
+           any, err := anypb.New(foo)
+           if err != nil {
+             ...
+           }
+           ...
+           foo := &pb.Foo{}
+           if err := any.UnmarshalTo(foo); err != nil {
+             ...
+           }
+
+      The pack methods provided by protobuf library will by default use
+      'type.googleapis.com/full.type.name' as the type URL and the unpack
+      methods only use the fully qualified type name after the last '/'
+      in the type URL, for example "foo.bar.com/x/y.z" will yield type
+      name "y.z".
+
+      JSON
+      ====
+      The JSON representation of an `Any` value uses the regular
+      representation of the deserialized, embedded message, with an
+      additional field `@type` which contains the type URL. Example:
+
+          package google.profile;
+          message Person {
+            string first_name = 1;
+            string last_name = 2;
+          }
+
+          {
+            "@type": "type.googleapis.com/google.profile.Person",
+            "firstName": <string>,
+            "lastName": <string>
+          }
+
+      If the embedded message type is well-known and has a custom JSON
+      representation, that representation will be embedded adding a field
+      `value` which holds the custom JSON in addition to the `@type`
+      field. Example (for message [google.protobuf.Duration][]):
+
+          {
+            "@type": "type.googleapis.com/google.protobuf.Duration",
+            "value": "1.212s"
+          }
+  rpcStatus:
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+      details:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/protobufAny'
+  snake_case_typesOneOfs:
+    type: object
+    properties:
+      firstSnakeCaseValue:
+        type: string
+        format: int64
+      secondSnakeCaseValue:
+        type: string
+        format: int64
+  snake_case_typesSimpleMessages:
+    type: object
+    properties:
+      longNameField:
+        type: string
+        format: int64

--- a/tests/proto/types.swagger.yaml
+++ b/tests/proto/types.swagger.yaml
@@ -1,0 +1,370 @@
+swagger: "2.0"
+info:
+  title: types.proto
+  version: version not set
+tags:
+  - name: TypesRPC
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /types/complex:
+    post:
+      summary: rpc GoogleRPC(Google) returns (Google);
+      operationId: TypesRPC_ComplexRPC
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/typesComplex'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/typesComplex'
+      tags:
+        - TypesRPC
+  /types/enums:
+    post:
+      operationId: TypesRPC_EnumsRPC
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/typesEnums'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/typesEnums'
+      tags:
+        - TypesRPC
+  /types/maps:
+    post:
+      operationId: TypesRPC_MapsRPC
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/typesMaps'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/typesMaps'
+      tags:
+        - TypesRPC
+  /types/oneofs:
+    post:
+      operationId: TypesRPC_OneOfsRPC
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/typesOneOfs'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/typesOneOfs'
+      tags:
+        - TypesRPC
+  /types/optional_scalars:
+    post:
+      operationId: TypesRPC_OptionalScalarsRPC
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/typesOptionalScalars'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/typesOptionalScalars'
+      tags:
+        - TypesRPC
+  /types/repeated:
+    post:
+      operationId: TypesRPC_RepeatedRPC
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/typesRepeated'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/typesRepeated'
+      tags:
+        - TypesRPC
+  /types/scalars:
+    post:
+      operationId: TypesRPC_ScalarsRPC
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/typesScalars'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/typesScalars'
+      tags:
+        - TypesRPC
+definitions:
+  protobufAny:
+    type: object
+    properties:
+      '@type':
+        type: string
+        description: |-
+          A URL/resource name that uniquely identifies the type of the serialized
+          protocol buffer message. This string must contain at least
+          one "/" character. The last segment of the URL's path must represent
+          the fully qualified name of the type (as in
+          `path/google.protobuf.Duration`). The name should be in a canonical form
+          (e.g., leading "." is not accepted).
+
+          In practice, teams usually precompile into the binary all types that they
+          expect it to use in the context of Any. However, for URLs which use the
+          scheme `http`, `https`, or no scheme, one can optionally set up a type
+          server that maps type URLs to message definitions as follows:
+
+          * If no scheme is provided, `https` is assumed.
+          * An HTTP GET on the URL must yield a [google.protobuf.Type][]
+            value in binary format, or produce an error.
+          * Applications are allowed to cache lookup results based on the
+            URL, or have them precompiled into a binary to avoid any
+            lookup. Therefore, binary compatibility needs to be preserved
+            on changes to types. (Use versioned type names to manage
+            breaking changes.)
+
+          Note: this functionality is not currently available in the official
+          protobuf release, and it is not used for type URLs beginning with
+          type.googleapis.com. As of May 2023, there are no widely used type server
+          implementations and no plans to implement one.
+
+          Schemes other than `http`, `https` (or the empty scheme) might be
+          used with implementation specific semantics.
+    additionalProperties: {}
+    description: |-
+      `Any` contains an arbitrary serialized protocol buffer message along with a
+      URL that describes the type of the serialized message.
+
+      Protobuf library provides support to pack/unpack Any values in the form
+      of utility functions or additional generated methods of the Any type.
+
+      Example 1: Pack and unpack a message in C++.
+
+          Foo foo = ...;
+          Any any;
+          any.PackFrom(foo);
+          ...
+          if (any.UnpackTo(&foo)) {
+            ...
+          }
+
+      Example 2: Pack and unpack a message in Java.
+
+          Foo foo = ...;
+          Any any = Any.pack(foo);
+          ...
+          if (any.is(Foo.class)) {
+            foo = any.unpack(Foo.class);
+          }
+          // or ...
+          if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+            foo = any.unpack(Foo.getDefaultInstance());
+          }
+
+       Example 3: Pack and unpack a message in Python.
+
+          foo = Foo(...)
+          any = Any()
+          any.Pack(foo)
+          ...
+          if any.Is(Foo.DESCRIPTOR):
+            any.Unpack(foo)
+            ...
+
+       Example 4: Pack and unpack a message in Go
+
+           foo := &pb.Foo{...}
+           any, err := anypb.New(foo)
+           if err != nil {
+             ...
+           }
+           ...
+           foo := &pb.Foo{}
+           if err := any.UnmarshalTo(foo); err != nil {
+             ...
+           }
+
+      The pack methods provided by protobuf library will by default use
+      'type.googleapis.com/full.type.name' as the type URL and the unpack
+      methods only use the fully qualified type name after the last '/'
+      in the type URL, for example "foo.bar.com/x/y.z" will yield type
+      name "y.z".
+
+      JSON
+      ====
+      The JSON representation of an `Any` value uses the regular
+      representation of the deserialized, embedded message, with an
+      additional field `@type` which contains the type URL. Example:
+
+          package google.profile;
+          message Person {
+            string first_name = 1;
+            string last_name = 2;
+          }
+
+          {
+            "@type": "type.googleapis.com/google.profile.Person",
+            "firstName": <string>,
+            "lastName": <string>
+          }
+
+      If the embedded message type is well-known and has a custom JSON
+      representation, that representation will be embedded adding a field
+      `value` which holds the custom JSON in addition to the `@type`
+      field. Example (for message [google.protobuf.Duration][]):
+
+          {
+            "@type": "type.googleapis.com/google.protobuf.Duration",
+            "value": "1.212s"
+          }
+  rpcStatus:
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+      details:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/protobufAny'
+  typesComplex:
+    type: object
+    properties:
+      scalars:
+        $ref: '#/definitions/typesScalars'
+      enums:
+        $ref: '#/definitions/typesEnums'
+      repeated:
+        $ref: '#/definitions/typesRepeated'
+      maps:
+        $ref: '#/definitions/typesMaps'
+      oneofs:
+        $ref: '#/definitions/typesOneOfs'
+        title: Google google = 6;
+  typesEnums:
+    type: object
+    properties:
+      values:
+        $ref: '#/definitions/typesValues'
+  typesMaps:
+    type: object
+    properties:
+      foo:
+        type: object
+        additionalProperties:
+          type: integer
+          format: int32
+  typesOneOfs:
+    type: object
+    properties:
+      foo:
+        type: string
+      bar:
+        type: string
+        format: byte
+      baz:
+        type: string
+        format: int64
+  typesOptionalScalars:
+    type: object
+    properties:
+      a:
+        type: number
+        format: double
+      b:
+        type: string
+        format: int64
+      c:
+        type: string
+      d:
+        type: string
+        format: byte
+      e:
+        type: boolean
+  typesRepeated:
+    type: object
+    properties:
+      foo:
+        type: array
+        items:
+          type: string
+  typesScalars:
+    type: object
+    properties:
+      a:
+        type: number
+        format: double
+      b:
+        type: string
+        format: int64
+      c:
+        type: string
+      d:
+        type: string
+        format: byte
+      e:
+        type: boolean
+  typesValues:
+    type: string
+    enum:
+      - FOO
+      - BAR
+    default: FOO

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -18,3 +18,6 @@ mod errors;
 
 #[cfg(test)]
 mod conversions;
+
+#[cfg(test)]
+mod snake_case_types;

--- a/tests/src/proto/convert_options.rs
+++ b/tests/src/proto/convert_options.rs
@@ -1,4 +1,3 @@
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConvertOptions {
@@ -11,7 +10,6 @@ pub struct ConvertOptions {
     #[prost(string, repeated, tag = "4")]
     pub attributes: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExtraFieldOptions {
@@ -20,7 +18,6 @@ pub struct ExtraFieldOptions {
     #[prost(string, tag = "2")]
     pub r#type: ::prost::alloc::string::String,
 }
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeriveOptions {

--- a/tests/src/proto/google.protobuf.rs
+++ b/tests/src/proto/google.protobuf.rs
@@ -88,7 +88,6 @@
 /// <http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime(>)
 /// ) to obtain a formatter capable of generating timestamps in this format.
 ///
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Timestamp {
@@ -190,7 +189,6 @@ pub struct Timestamp {
 ///        "value": "1.212s"
 ///      }
 ///
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Any {
@@ -231,7 +229,6 @@ pub struct Any {
 }
 /// The protocol compiler can output a FileDescriptorSet containing the .proto
 /// files it parses.
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileDescriptorSet {
@@ -239,7 +236,6 @@ pub struct FileDescriptorSet {
     pub file: ::prost::alloc::vec::Vec<FileDescriptorProto>,
 }
 /// Describes a complete .proto file.
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileDescriptorProto {
@@ -287,7 +283,6 @@ pub struct FileDescriptorProto {
     pub edition: ::core::option::Option<i32>,
 }
 /// Describes a message type.
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DescriptorProto {
@@ -316,7 +311,6 @@ pub struct DescriptorProto {
 }
 /// Nested message and enum types in `DescriptorProto`.
 pub mod descriptor_proto {
-    #[actix_prost_macros::serde]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ExtensionRange {
@@ -332,7 +326,6 @@ pub mod descriptor_proto {
     /// Range of reserved tag numbers. Reserved tag numbers may not be used by
     /// fields or extension ranges in the same message. Reserved ranges may
     /// not overlap.
-    #[actix_prost_macros::serde]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ReservedRange {
@@ -344,7 +337,6 @@ pub mod descriptor_proto {
         pub end: ::core::option::Option<i32>,
     }
 }
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExtensionRangeOptions {
@@ -372,7 +364,6 @@ pub struct ExtensionRangeOptions {
 }
 /// Nested message and enum types in `ExtensionRangeOptions`.
 pub mod extension_range_options {
-    #[actix_prost_macros::serde]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Declaration {
@@ -399,7 +390,6 @@ pub mod extension_range_options {
         pub repeated: ::core::option::Option<bool>,
     }
     /// The verification state of the extension range.
-    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -439,7 +429,6 @@ pub mod extension_range_options {
     }
 }
 /// Describes a field within a message.
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldDescriptorProto {
@@ -508,7 +497,6 @@ pub struct FieldDescriptorProto {
 }
 /// Nested message and enum types in `FieldDescriptorProto`.
 pub mod field_descriptor_proto {
-    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -608,7 +596,6 @@ pub mod field_descriptor_proto {
             }
         }
     }
-    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -654,7 +641,6 @@ pub mod field_descriptor_proto {
     }
 }
 /// Describes a oneof.
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OneofDescriptorProto {
@@ -664,7 +650,6 @@ pub struct OneofDescriptorProto {
     pub options: ::core::option::Option<OneofOptions>,
 }
 /// Describes an enum type.
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumDescriptorProto {
@@ -694,7 +679,6 @@ pub mod enum_descriptor_proto {
     /// Note that this is distinct from DescriptorProto.ReservedRange in that it
     /// is inclusive such that it can appropriately represent the entire int32
     /// domain.
-    #[actix_prost_macros::serde]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct EnumReservedRange {
@@ -707,7 +691,6 @@ pub mod enum_descriptor_proto {
     }
 }
 /// Describes a value within an enum.
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumValueDescriptorProto {
@@ -719,7 +702,6 @@ pub struct EnumValueDescriptorProto {
     pub options: ::core::option::Option<EnumValueOptions>,
 }
 /// Describes a service.
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServiceDescriptorProto {
@@ -731,7 +713,6 @@ pub struct ServiceDescriptorProto {
     pub options: ::core::option::Option<ServiceOptions>,
 }
 /// Describes a method of a service.
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MethodDescriptorProto {
@@ -752,7 +733,6 @@ pub struct MethodDescriptorProto {
     #[prost(bool, optional, tag = "6", default = "false")]
     pub server_streaming: ::core::option::Option<bool>,
 }
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileOptions {
@@ -876,7 +856,6 @@ pub struct FileOptions {
 /// Nested message and enum types in `FileOptions`.
 pub mod file_options {
     /// Generated classes can be optimized for speed or code size.
-    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -922,7 +901,6 @@ pub mod file_options {
         }
     }
 }
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MessageOptions {
@@ -1000,7 +978,6 @@ pub struct MessageOptions {
     #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldOptions {
@@ -1108,7 +1085,6 @@ pub struct FieldOptions {
 }
 /// Nested message and enum types in `FieldOptions`.
 pub mod field_options {
-    #[actix_prost_macros::serde]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct EditionDefault {
@@ -1119,7 +1095,6 @@ pub mod field_options {
         pub value: ::core::option::Option<::prost::alloc::string::String>,
     }
     /// Information about the support window of a feature.
-    #[actix_prost_macros::serde]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct FeatureSupport {
@@ -1142,7 +1117,6 @@ pub mod field_options {
         #[prost(enumeration = "super::Edition", optional, tag = "4")]
         pub edition_removed: ::core::option::Option<i32>,
     }
-    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1189,7 +1163,6 @@ pub mod field_options {
             }
         }
     }
-    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1235,7 +1208,6 @@ pub mod field_options {
     /// If set to RETENTION_SOURCE, the option will be omitted from the binary.
     /// Note: as of January 2023, support for this is in progress and does not yet
     /// have an effect (b/264593489).
-    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1279,7 +1251,6 @@ pub mod field_options {
     /// as an option. If it is unset, then the field may be freely used as an
     /// option on any kind of entity. Note: as of January 2023, support for this is
     /// in progress and does not yet have an effect (b/264593489).
-    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1343,7 +1314,6 @@ pub mod field_options {
         }
     }
 }
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OneofOptions {
@@ -1354,7 +1324,6 @@ pub struct OneofOptions {
     #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumOptions {
@@ -1384,7 +1353,6 @@ pub struct EnumOptions {
     #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumValueOptions {
@@ -1409,7 +1377,6 @@ pub struct EnumValueOptions {
     #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServiceOptions {
@@ -1426,7 +1393,6 @@ pub struct ServiceOptions {
     #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MethodOptions {
@@ -1455,7 +1421,6 @@ pub mod method_options {
     /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
     /// or neither? HTTP based RPC implementation may choose GET verb for safe
     /// methods, and PUT verb for idempotent methods instead of the default POST.
-    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1504,7 +1469,6 @@ pub mod method_options {
 /// options protos in descriptor objects (e.g. returned by Descriptor::options(),
 /// or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
 /// in them.
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UninterpretedOption {
@@ -1532,7 +1496,6 @@ pub mod uninterpreted_option {
     /// extension (denoted with parentheses in options specs in .proto files).
     /// E.g.,{ ["foo", false], ["bar.baz", true], ["moo", false] } represents
     /// "foo.(bar.baz).moo".
-    #[actix_prost_macros::serde]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NamePart {
@@ -1548,7 +1511,6 @@ pub mod uninterpreted_option {
 /// readability, but leave us very open to this scenario.  A future feature will
 /// be designed and implemented to handle this, hopefully before we ever hit a
 /// conflict here.
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FeatureSet {
@@ -1567,7 +1529,6 @@ pub struct FeatureSet {
 }
 /// Nested message and enum types in `FeatureSet`.
 pub mod feature_set {
-    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1610,7 +1571,6 @@ pub mod feature_set {
             }
         }
     }
-    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1650,7 +1610,6 @@ pub mod feature_set {
             }
         }
     }
-    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1690,7 +1649,6 @@ pub mod feature_set {
             }
         }
     }
-    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1730,7 +1688,6 @@ pub mod feature_set {
             }
         }
     }
-    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1770,7 +1727,6 @@ pub mod feature_set {
             }
         }
     }
-    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1815,7 +1771,6 @@ pub mod feature_set {
 /// messages are generated from FeatureSet extensions and can be used to seed
 /// feature resolution. The resolution with this object becomes a simple search
 /// for the closest matching edition, followed by proto merges.
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FeatureSetDefaults {
@@ -1838,7 +1793,6 @@ pub mod feature_set_defaults {
     /// defaults. Not all editions may be contained here.  For a given edition,
     /// the defaults at the closest matching edition ordered at or before it should
     /// be used.  This field must be in strict ascending order by edition.
-    #[actix_prost_macros::serde]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct FeatureSetEditionDefault {
@@ -1854,7 +1808,6 @@ pub mod feature_set_defaults {
 }
 /// Encapsulates information about the original source file from which a
 /// FileDescriptorProto was generated.
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SourceCodeInfo {
@@ -1906,7 +1859,6 @@ pub struct SourceCodeInfo {
 }
 /// Nested message and enum types in `SourceCodeInfo`.
 pub mod source_code_info {
-    #[actix_prost_macros::serde]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Location {
@@ -2002,7 +1954,6 @@ pub mod source_code_info {
 /// Describes the relationship between generated code and its original source
 /// file. A GeneratedCodeInfo message is associated with only one generated
 /// source file, but may contain references to different source .proto files.
-#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GeneratedCodeInfo {
@@ -2013,7 +1964,6 @@ pub struct GeneratedCodeInfo {
 }
 /// Nested message and enum types in `GeneratedCodeInfo`.
 pub mod generated_code_info {
-    #[actix_prost_macros::serde]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Annotation {
@@ -2040,7 +1990,6 @@ pub mod generated_code_info {
     pub mod annotation {
         /// Represents the identified object's effect on the element in the original
         /// .proto file.
-        #[actix_prost_macros::serde]
         #[derive(
             Clone,
             Copy,
@@ -2086,7 +2035,6 @@ pub mod generated_code_info {
     }
 }
 /// The full set of known editions.
-#[actix_prost_macros::serde]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum Edition {

--- a/tests/src/proto/google.protobuf.rs
+++ b/tests/src/proto/google.protobuf.rs
@@ -485,12 +485,12 @@ pub struct FieldDescriptorProto {
     /// If true, this is a proto3 "optional". When a proto3 field is optional, it
     /// tracks presence regardless of field type.
     ///
-    /// When proto3_optional is true, this field must be belong to a oneof to
-    /// signal to old proto3 clients that presence is tracked for this field. This
-    /// oneof is known as a "synthetic" oneof, and this field must be its sole
-    /// member (each proto3 optional field gets its own synthetic oneof). Synthetic
-    /// oneofs exist in the descriptor only, and do not generate any API. Synthetic
-    /// oneofs must be ordered after all "real" oneofs.
+    /// When proto3_optional is true, this field must belong to a oneof to signal
+    /// to old proto3 clients that presence is tracked for this field. This oneof
+    /// is known as a "synthetic" oneof, and this field must be its sole member
+    /// (each proto3 optional field gets its own synthetic oneof). Synthetic oneofs
+    /// exist in the descriptor only, and do not generate any API. Synthetic oneofs
+    /// must be ordered after all "real" oneofs.
     ///
     /// For message fields, proto3_optional doesn't create any semantic change,
     /// since non-repeated message fields always track presence. However it still
@@ -781,12 +781,16 @@ pub struct FileOptions {
     #[deprecated]
     #[prost(bool, optional, tag = "20")]
     pub java_generate_equals_and_hash: ::core::option::Option<bool>,
-    /// If set true, then the Java2 code generator will generate code that
-    /// throws an exception whenever an attempt is made to assign a non-UTF-8
-    /// byte sequence to a string field.
-    /// Message reflection will do the same.
-    /// However, an extension field still accepts non-UTF-8 byte sequences.
-    /// This option has no effect on when used with the lite runtime.
+    /// A proto2 file can set this to true to opt in to UTF-8 checking for Java,
+    /// which will throw an exception if invalid UTF-8 is parsed from the wire or
+    /// assigned to a string field.
+    ///
+    /// TODO: clarify exactly what kinds of field types this option
+    /// applies to, and update these docs accordingly.
+    ///
+    /// Proto3 files already perform these checks. Setting the option explicitly to
+    /// false has no effect: it cannot be used to opt proto3 files out of UTF-8
+    /// checks.
     #[prost(bool, optional, tag = "27", default = "false")]
     pub java_string_check_utf8: ::core::option::Option<bool>,
     #[prost(
@@ -819,8 +823,6 @@ pub struct FileOptions {
     pub java_generic_services: ::core::option::Option<bool>,
     #[prost(bool, optional, tag = "18", default = "false")]
     pub py_generic_services: ::core::option::Option<bool>,
-    #[prost(bool, optional, tag = "42", default = "false")]
-    pub php_generic_services: ::core::option::Option<bool>,
     /// Is this file deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
     /// for everything in the file, or it will be completely ignored; in the very
@@ -955,10 +957,6 @@ pub struct MessageOptions {
     /// this is a formalization for deprecating messages.
     #[prost(bool, optional, tag = "3", default = "false")]
     pub deprecated: ::core::option::Option<bool>,
-    /// NOTE: Do not set the option in .proto files. Always use the maps syntax
-    /// instead. The option should only be implicitly set by the proto compiler
-    /// parser.
-    ///
     /// Whether the message is an automatically generated map entry type for the
     /// maps field.
     ///
@@ -976,6 +974,10 @@ pub struct MessageOptions {
     /// use a native map in the target language to hold the keys and values.
     /// The reflection APIs in such implementations still need to work as
     /// if the field is a repeated message field.
+    ///
+    /// NOTE: Do not set the option in .proto files. Always use the maps syntax
+    /// instead. The option should only be implicitly set by the proto compiler
+    /// parser.
     #[prost(bool, optional, tag = "7")]
     pub map_entry: ::core::option::Option<bool>,
     /// Enable the legacy handling of JSON field name conflicts.  This lowercases
@@ -1059,19 +1061,11 @@ pub struct FieldOptions {
     /// call from multiple threads concurrently, while non-const methods continue
     /// to require exclusive access.
     ///
-    /// Note that implementations may choose not to check required fields within
-    /// a lazy sub-message.  That is, calling IsInitialized() on the outer message
-    /// may return true even if the inner message has missing required fields.
-    /// This is necessary because otherwise the inner message would have to be
-    /// parsed in order to perform the check, defeating the purpose of lazy
-    /// parsing.  An implementation which chooses not to check required fields
-    /// must be consistent about it.  That is, for any particular sub-message, the
-    /// implementation must either *always* check its required fields, or *never*
-    /// check its required fields, regardless of whether or not the message has
-    /// been parsed.
-    ///
-    /// As of May 2022, lazy verifies the contents of the byte stream during
-    /// parsing.  An invalid byte stream will cause the overall parsing to fail.
+    /// Note that lazy message fields are still eagerly verified to check
+    /// ill-formed wireformat or missing required fields. Calling IsInitialized()
+    /// on the outer message would fail if the inner message has missing required
+    /// fields. Failed verification would result in parsing failure (except when
+    /// uninitialized messages are acceptable).
     #[prost(bool, optional, tag = "5", default = "false")]
     pub lazy: ::core::option::Option<bool>,
     /// unverified_lazy does no correctness checks on the byte stream. This should
@@ -1106,6 +1100,8 @@ pub struct FieldOptions {
     /// Any features defined in the specific edition.
     #[prost(message, optional, tag = "21")]
     pub features: ::core::option::Option<FeatureSet>,
+    #[prost(message, optional, tag = "22")]
+    pub feature_support: ::core::option::Option<field_options::FeatureSupport>,
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
@@ -1121,6 +1117,30 @@ pub mod field_options {
         /// Textproto value.
         #[prost(string, optional, tag = "2")]
         pub value: ::core::option::Option<::prost::alloc::string::String>,
+    }
+    /// Information about the support window of a feature.
+    #[actix_prost_macros::serde]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct FeatureSupport {
+        /// The edition that this feature was first available in.  In editions
+        /// earlier than this one, the default assigned to EDITION_LEGACY will be
+        /// used, and proto files will not be able to override it.
+        #[prost(enumeration = "super::Edition", optional, tag = "1")]
+        pub edition_introduced: ::core::option::Option<i32>,
+        /// The edition this feature becomes deprecated in.  Using this after this
+        /// edition may trigger warnings.
+        #[prost(enumeration = "super::Edition", optional, tag = "2")]
+        pub edition_deprecated: ::core::option::Option<i32>,
+        /// The deprecation warning text if this feature is used after the edition it
+        /// was marked deprecated in.
+        #[prost(string, optional, tag = "3")]
+        pub deprecation_warning: ::core::option::Option<::prost::alloc::string::String>,
+        /// The edition this feature is no longer available in.  In editions after
+        /// this one, the last default assigned will be used, and proto files will
+        /// not be able to override it.
+        #[prost(enumeration = "super::Edition", optional, tag = "4")]
+        pub edition_removed: ::core::option::Option<i32>,
     }
     #[actix_prost_macros::serde]
     #[derive(
@@ -1382,6 +1402,9 @@ pub struct EnumValueOptions {
     /// credentials.
     #[prost(bool, optional, tag = "3", default = "false")]
     pub debug_redact: ::core::option::Option<bool>,
+    /// Information about the support window of a feature value.
+    #[prost(message, optional, tag = "4")]
+    pub feature_support: ::core::option::Option<field_options::FeatureSupport>,
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
@@ -1682,8 +1705,8 @@ pub mod feature_set {
     #[repr(i32)]
     pub enum Utf8Validation {
         Unknown = 0,
-        None = 1,
         Verify = 2,
+        None = 3,
     }
     impl Utf8Validation {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -1693,16 +1716,16 @@ pub mod feature_set {
         pub fn as_str_name(&self) -> &'static str {
             match self {
                 Utf8Validation::Unknown => "UTF8_VALIDATION_UNKNOWN",
-                Utf8Validation::None => "NONE",
                 Utf8Validation::Verify => "VERIFY",
+                Utf8Validation::None => "NONE",
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
         pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
             match value {
                 "UTF8_VALIDATION_UNKNOWN" => Some(Self::Unknown),
-                "NONE" => Some(Self::None),
                 "VERIFY" => Some(Self::Verify),
+                "NONE" => Some(Self::None),
                 _ => None,
             }
         }
@@ -1821,8 +1844,12 @@ pub mod feature_set_defaults {
     pub struct FeatureSetEditionDefault {
         #[prost(enumeration = "super::Edition", optional, tag = "3")]
         pub edition: ::core::option::Option<i32>,
-        #[prost(message, optional, tag = "2")]
-        pub features: ::core::option::Option<super::FeatureSet>,
+        /// Defaults of features that can be overridden in this edition.
+        #[prost(message, optional, tag = "4")]
+        pub overridable_features: ::core::option::Option<super::FeatureSet>,
+        /// Defaults of features that can't be overridden in this edition.
+        #[prost(message, optional, tag = "5")]
+        pub fixed_features: ::core::option::Option<super::FeatureSet>,
     }
 }
 /// Encapsulates information about the original source file from which a
@@ -1887,7 +1914,7 @@ pub mod source_code_info {
         /// location.
         ///
         /// Each element is a field number or an index.  They form a path from
-        /// the root FileDescriptorProto to the place where the definition occurs.
+        /// the root FileDescriptorProto to the place where the definition appears.
         /// For example, this path:
         ///    [ 4, 3, 2, 7, 1 ]
         /// refers to:
@@ -2065,6 +2092,9 @@ pub mod generated_code_info {
 pub enum Edition {
     /// A placeholder for an unknown edition value.
     Unknown = 0,
+    /// A placeholder edition for specifying default behaviors *before* a feature
+    /// was first introduced.  This is effectively an "infinite past".
+    Legacy = 900,
     /// Legacy syntax "editions".  These pre-date editions, but behave much like
     /// distinct editions.  These can't be used to specify the edition of proto
     /// files, but feature definitions must supply proto2/proto3 defaults for
@@ -2075,6 +2105,7 @@ pub enum Edition {
     /// should not be depended on, but they will always be time-ordered for easy
     /// comparison.
     Edition2023 = 1000,
+    Edition2024 = 1001,
     /// Placeholder editions for testing feature resolution.  These should not be
     /// used or relyed on outside of tests.
     Edition1TestOnly = 1,
@@ -2082,6 +2113,10 @@ pub enum Edition {
     Edition99997TestOnly = 99997,
     Edition99998TestOnly = 99998,
     Edition99999TestOnly = 99999,
+    /// Placeholder for specifying unbounded edition support.  This should only
+    /// ever be used by plugins that can expect to never require any changes to
+    /// support a new edition.
+    Max = 2147483647,
 }
 impl Edition {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -2091,28 +2126,34 @@ impl Edition {
     pub fn as_str_name(&self) -> &'static str {
         match self {
             Edition::Unknown => "EDITION_UNKNOWN",
+            Edition::Legacy => "EDITION_LEGACY",
             Edition::Proto2 => "EDITION_PROTO2",
             Edition::Proto3 => "EDITION_PROTO3",
             Edition::Edition2023 => "EDITION_2023",
+            Edition::Edition2024 => "EDITION_2024",
             Edition::Edition1TestOnly => "EDITION_1_TEST_ONLY",
             Edition::Edition2TestOnly => "EDITION_2_TEST_ONLY",
             Edition::Edition99997TestOnly => "EDITION_99997_TEST_ONLY",
             Edition::Edition99998TestOnly => "EDITION_99998_TEST_ONLY",
             Edition::Edition99999TestOnly => "EDITION_99999_TEST_ONLY",
+            Edition::Max => "EDITION_MAX",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
             "EDITION_UNKNOWN" => Some(Self::Unknown),
+            "EDITION_LEGACY" => Some(Self::Legacy),
             "EDITION_PROTO2" => Some(Self::Proto2),
             "EDITION_PROTO3" => Some(Self::Proto3),
             "EDITION_2023" => Some(Self::Edition2023),
+            "EDITION_2024" => Some(Self::Edition2024),
             "EDITION_1_TEST_ONLY" => Some(Self::Edition1TestOnly),
             "EDITION_2_TEST_ONLY" => Some(Self::Edition2TestOnly),
             "EDITION_99997_TEST_ONLY" => Some(Self::Edition99997TestOnly),
             "EDITION_99998_TEST_ONLY" => Some(Self::Edition99998TestOnly),
             "EDITION_99999_TEST_ONLY" => Some(Self::Edition99999TestOnly),
+            "EDITION_MAX" => Some(Self::Max),
             _ => None,
         }
     }

--- a/tests/src/proto/mod.rs
+++ b/tests/src/proto/mod.rs
@@ -2,4 +2,5 @@ pub mod conversions;
 pub mod errors;
 pub mod rest;
 pub mod simple;
+pub mod snake_case_types;
 pub mod types;

--- a/tests/src/proto/snake_case_types.rs
+++ b/tests/src/proto/snake_case_types.rs
@@ -106,6 +106,42 @@ pub mod snake_case_types_rpc_actix {
             );
     }
 }
+#[derive(Clone, Debug)]
+pub struct SimpleMessagesInternal {
+    pub long_name_field: i64,
+}
+impl convert_trait::TryConvert<SimpleMessages> for SimpleMessagesInternal {
+    fn try_convert(from: SimpleMessages) -> Result<Self, String> {
+        Ok(Self {
+            long_name_field: from.long_name_field,
+        })
+    }
+}
+impl convert_trait::TryConvert<SimpleMessagesInternal> for SimpleMessages {
+    fn try_convert(from: SimpleMessagesInternal) -> Result<Self, String> {
+        Ok(Self {
+            long_name_field: from.long_name_field,
+        })
+    }
+}
+#[derive(Clone, Debug)]
+pub struct OneOfsInternal {
+    pub snake_case_values: ::core::option::Option<one_ofs::SnakeCaseValues>,
+}
+impl convert_trait::TryConvert<OneOfs> for OneOfsInternal {
+    fn try_convert(from: OneOfs) -> Result<Self, String> {
+        Ok(Self {
+            snake_case_values: from.snake_case_values,
+        })
+    }
+}
+impl convert_trait::TryConvert<OneOfsInternal> for OneOfs {
+    fn try_convert(from: OneOfsInternal) -> Result<Self, String> {
+        Ok(Self {
+            snake_case_values: from.snake_case_values,
+        })
+    }
+}
 /// Generated client implementations.
 pub mod snake_case_types_rpc_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]

--- a/tests/src/proto/snake_case_types.rs
+++ b/tests/src/proto/snake_case_types.rs
@@ -1,0 +1,408 @@
+#[actix_prost_macros::serde(rename_all = "snake_case")]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SimpleMessages {
+    #[prost(int64, tag = "1")]
+    pub long_name_field: i64,
+}
+#[actix_prost_macros::serde(rename_all = "snake_case")]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OneOfs {
+    #[prost(oneof = "one_ofs::SnakeCaseValues", tags = "1, 2")]
+    pub snake_case_values: ::core::option::Option<one_ofs::SnakeCaseValues>,
+}
+/// Nested message and enum types in `OneOfs`.
+pub mod one_ofs {
+    #[actix_prost_macros::serde(rename_all = "snake_case")]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum SnakeCaseValues {
+        #[prost(int64, tag = "1")]
+        FirstSnakeCaseValue(i64),
+        #[prost(int64, tag = "2")]
+        SecondSnakeCaseValue(i64),
+    }
+}
+pub mod snake_case_types_rpc_actix {
+    #![allow(unused_variables, dead_code, missing_docs)]
+    use super::*;
+    use super::snake_case_types_rpc_server::SnakeCaseTypesRpc;
+    use std::sync::Arc;
+    #[actix_prost_macros::serde(rename_all = "snake_case")]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct SimpleMessagesRPCJson {
+        #[prost(int64, tag = "1")]
+        pub long_name_field: i64,
+    }
+    #[actix_prost_macros::serde(rename_all = "snake_case")]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct OneOfsRPCJson {
+        #[prost(oneof = "one_ofs::SnakeCaseValues", tags = "1, 2")]
+        pub snake_case_values: ::core::option::Option<one_ofs::SnakeCaseValues>,
+    }
+    async fn call_simple_messages_rpc(
+        service: ::actix_web::web::Data<dyn SnakeCaseTypesRpc + Sync + Send + 'static>,
+        http_request: ::actix_web::HttpRequest,
+        payload: ::actix_web::web::Payload,
+    ) -> Result<::actix_web::web::Json<SimpleMessages>, ::actix_prost::Error> {
+        let mut payload = payload.into_inner();
+        let json = <::actix_web::web::Json<
+            SimpleMessagesRPCJson,
+        > as ::actix_web::FromRequest>::from_request(&http_request, &mut payload)
+            .await
+            .map_err(|err| ::actix_prost::Error::from_actix(
+                err,
+                ::tonic::Code::InvalidArgument,
+            ))?
+            .into_inner();
+        let request = SimpleMessages {
+            long_name_field: json.long_name_field,
+        };
+        let request = ::actix_prost::new_request(request, &http_request);
+        let response = service.simple_messages_rpc(request).await?;
+        let response = response.into_inner();
+        Ok(::actix_web::web::Json(response))
+    }
+    async fn call_one_ofs_rpc(
+        service: ::actix_web::web::Data<dyn SnakeCaseTypesRpc + Sync + Send + 'static>,
+        http_request: ::actix_web::HttpRequest,
+        payload: ::actix_web::web::Payload,
+    ) -> Result<::actix_web::web::Json<OneOfs>, ::actix_prost::Error> {
+        let mut payload = payload.into_inner();
+        let json = <::actix_web::web::Json<
+            OneOfsRPCJson,
+        > as ::actix_web::FromRequest>::from_request(&http_request, &mut payload)
+            .await
+            .map_err(|err| ::actix_prost::Error::from_actix(
+                err,
+                ::tonic::Code::InvalidArgument,
+            ))?
+            .into_inner();
+        let request = OneOfs {
+            snake_case_values: json.snake_case_values,
+        };
+        let request = ::actix_prost::new_request(request, &http_request);
+        let response = service.one_ofs_rpc(request).await?;
+        let response = response.into_inner();
+        Ok(::actix_web::web::Json(response))
+    }
+    pub fn route_snake_case_types_rpc(
+        config: &mut ::actix_web::web::ServiceConfig,
+        service: Arc<dyn SnakeCaseTypesRpc + Send + Sync + 'static>,
+    ) {
+        config.app_data(::actix_web::web::Data::from(service));
+        config
+            .route(
+                "/snake-case-types/simple-messages",
+                ::actix_web::web::post().to(call_simple_messages_rpc),
+            );
+        config
+            .route(
+                "/snake-case-types/oneofs",
+                ::actix_web::web::post().to(call_one_ofs_rpc),
+            );
+    }
+}
+/// Generated client implementations.
+pub mod snake_case_types_rpc_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct SnakeCaseTypesRpcClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl SnakeCaseTypesRpcClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> SnakeCaseTypesRpcClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> SnakeCaseTypesRpcClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            SnakeCaseTypesRpcClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        pub async fn simple_messages_rpc(
+            &mut self,
+            request: impl tonic::IntoRequest<super::SimpleMessages>,
+        ) -> Result<tonic::Response<super::SimpleMessages>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/snake_case_types.SnakeCaseTypesRPC/SimpleMessagesRPC",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn one_ofs_rpc(
+            &mut self,
+            request: impl tonic::IntoRequest<super::OneOfs>,
+        ) -> Result<tonic::Response<super::OneOfs>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/snake_case_types.SnakeCaseTypesRPC/OneOfsRPC",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+pub mod snake_case_types_rpc_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with SnakeCaseTypesRpcServer.
+    #[async_trait]
+    pub trait SnakeCaseTypesRpc: Send + Sync + 'static {
+        async fn simple_messages_rpc(
+            &self,
+            request: tonic::Request<super::SimpleMessages>,
+        ) -> Result<tonic::Response<super::SimpleMessages>, tonic::Status>;
+        async fn one_ofs_rpc(
+            &self,
+            request: tonic::Request<super::OneOfs>,
+        ) -> Result<tonic::Response<super::OneOfs>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct SnakeCaseTypesRpcServer<T: SnakeCaseTypesRpc> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: SnakeCaseTypesRpc> SnakeCaseTypesRpcServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for SnakeCaseTypesRpcServer<T>
+    where
+        T: SnakeCaseTypesRpc,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/snake_case_types.SnakeCaseTypesRPC/SimpleMessagesRPC" => {
+                    #[allow(non_camel_case_types)]
+                    struct SimpleMessagesRPCSvc<T: SnakeCaseTypesRpc>(pub Arc<T>);
+                    impl<
+                        T: SnakeCaseTypesRpc,
+                    > tonic::server::UnaryService<super::SimpleMessages>
+                    for SimpleMessagesRPCSvc<T> {
+                        type Response = super::SimpleMessages;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::SimpleMessages>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).simple_messages_rpc(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = SimpleMessagesRPCSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/snake_case_types.SnakeCaseTypesRPC/OneOfsRPC" => {
+                    #[allow(non_camel_case_types)]
+                    struct OneOfsRPCSvc<T: SnakeCaseTypesRpc>(pub Arc<T>);
+                    impl<T: SnakeCaseTypesRpc> tonic::server::UnaryService<super::OneOfs>
+                    for OneOfsRPCSvc<T> {
+                        type Response = super::OneOfs;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::OneOfs>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).one_ofs_rpc(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = OneOfsRPCSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: SnakeCaseTypesRpc> Clone for SnakeCaseTypesRpcServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
+        }
+    }
+    impl<T: SnakeCaseTypesRpc> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: SnakeCaseTypesRpc> tonic::server::NamedService
+    for SnakeCaseTypesRpcServer<T> {
+        const NAME: &'static str = "snake_case_types.SnakeCaseTypesRPC";
+    }
+}

--- a/tests/src/snake_case_types.rs
+++ b/tests/src/snake_case_types.rs
@@ -1,0 +1,72 @@
+use crate::{
+    proto::snake_case_types::{
+        snake_case_types_rpc_actix::route_snake_case_types_rpc,
+        snake_case_types_rpc_server::SnakeCaseTypesRpc, OneOfs, SimpleMessages,
+    },
+    test,
+};
+use actix_web::{App, HttpServer};
+use pretty_assertions::assert_eq;
+use std::{net::SocketAddr, sync::Arc};
+use tonic::{Request, Response, Status};
+
+#[derive(Default)]
+struct SnakeCaseTypesServer {}
+
+#[async_trait::async_trait]
+impl SnakeCaseTypesRpc for SnakeCaseTypesServer {
+    async fn simple_messages_rpc(
+        &self,
+        request: Request<SimpleMessages>,
+    ) -> Result<Response<SimpleMessages>, Status> {
+        Ok(Response::new(request.into_inner()))
+    }
+
+    async fn one_ofs_rpc(&self, request: Request<OneOfs>) -> Result<Response<OneOfs>, Status> {
+        Ok(Response::new(request.into_inner()))
+    }
+}
+
+async fn assert_ping(addr: &SocketAddr, path: &str, body: String) {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://localhost:{}{}", addr.port(), path))
+        .body(body.clone())
+        .header("Content-Type", "application/json")
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let resp: serde_json::Value = serde_json::from_str(&resp)
+        .unwrap_or_else(|_| panic!("could not parse json, got: {}", resp));
+    assert_eq!(body, resp);
+}
+
+#[tokio::test]
+async fn ping() {
+    let server = Arc::new(SnakeCaseTypesServer::default());
+    let addr: SocketAddr = test::get_test_addr();
+    let http = HttpServer::new(move || {
+        App::new().configure(|config| route_snake_case_types_rpc(config, server.clone()))
+    })
+    .bind(addr)
+    .unwrap();
+
+    tokio::spawn(http.run());
+
+    assert_ping(
+        &addr,
+        "/snake-case-types/simple-messages",
+        r#"{ "long_name_field": "42" }"#.into(),
+    )
+    .await;
+    assert_ping(
+        &addr,
+        "/snake-case-types/oneofs",
+        r#"{ "first_snake_case_value": "42" }"#.into(),
+    )
+    .await;
+}


### PR DESCRIPTION
Rn if you specify `serde(rename_all="snake_case")` as a common type attribute, one of values are still serialized and deserialized using `camelCase` notation. The PR makes them using `snake_case` as well