### PR TITLE
feat(actix-prost-macros): allow serde overrides for type attributes

### DIFF
--- a/actix-prost-macros/src/lib.rs
+++ b/actix-prost-macros/src/lib.rs
@@ -24,16 +24,12 @@ fn find_rename_all(attrs: &[syn::NestedMeta]) -> Option<String> {
     None
 }
 
-/// Checks if any other `actix_prost_macros::serde` attribute exist
-/// for the item defined after the current attribute.
+/// Checks if any other `actix_prost_macros::serde` attribute exists
+/// for the item defined **after** the current attribute.
 fn has_other_actix_prost_serde_attributes(item_attributes: &[Attribute]) -> bool {
-    for attribute in item_attributes {
-        if attribute.path == syn::parse_quote!(actix_prost_macros::serde) {
-            return true;
-        }
-    }
-
-    false
+    item_attributes
+        .iter()
+        .any(|attribute| attribute.path == syn::parse_quote!(actix_prost_macros::serde))
 }
 
 #[proc_macro_attribute]

--- a/actix-prost-macros/src/lib.rs
+++ b/actix-prost-macros/src/lib.rs
@@ -2,7 +2,7 @@ use enums::process_enum;
 use field::process_field;
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{AttributeArgs, Item};
+use syn::{Attribute, AttributeArgs, Item};
 
 mod enums;
 mod field;
@@ -24,6 +24,18 @@ fn find_rename_all(attrs: &[syn::NestedMeta]) -> Option<String> {
     None
 }
 
+/// Checks if any other `actix_prost_macros::serde` attribute exist
+/// for the item defined after the current attribute.
+fn has_other_actix_prost_serde_attributes(item_attributes: &[Attribute]) -> bool {
+    for attribute in item_attributes {
+        if attribute.path == syn::parse_quote!(actix_prost_macros::serde) {
+            return true;
+        }
+    }
+
+    false
+}
+
 #[proc_macro_attribute]
 pub fn serde(attrs: TokenStream, item: TokenStream) -> TokenStream {
     let mut item = syn::parse_macro_input!(item as Item);
@@ -32,7 +44,7 @@ pub fn serde(attrs: TokenStream, item: TokenStream) -> TokenStream {
     let maybe_rename = match find_rename_all(&attrs) {
         // 'none' option makes it possible to use rust default case
         // by default (which is snake_case for structs and PascalCase for enums),
-        // and overwrite that value for some of the messages. For us it is a way
+        // and overwrite that value for some of the messages. For us, it is a way
         // to make most of the messages using snake_case, while small part of them
         // using camelCase.
         Some(rename) if rename.to_lowercase() == "none" => None,
@@ -41,8 +53,12 @@ pub fn serde(attrs: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let mut result = quote::quote!();
+    // Checking that no other `actix_prost_macros::serde` attributes exist for an item
+    // allows us to override 'rename_all' attribute for the type.
+    // That allows to specify a default serialization case convention and override it
+    // for some of the types only (e.g., for legacy reasons).
     match &mut item {
-        syn::Item::Enum(item) => {
+        syn::Item::Enum(item) if !has_other_actix_prost_serde_attributes(&item.attrs) => {
             let mut need_serde_as = false;
             for variant in item.variants.iter_mut() {
                 for field in variant.fields.iter_mut() {
@@ -61,7 +77,7 @@ pub fn serde(attrs: TokenStream, item: TokenStream) -> TokenStream {
             let enums = process_enum(item, maybe_rename.clone());
             result = quote::quote!(#result #enums);
         }
-        syn::Item::Struct(item) => {
+        syn::Item::Struct(item) if !has_other_actix_prost_serde_attributes(&item.attrs) => {
             let mut need_serde_as = false;
             for field in item.fields.iter_mut() {
                 let (attr, need) = process_field(field);

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -31,9 +31,9 @@ fn compile(
         .type_attribute(".types", "#[actix_prost_macros::serde]")
         .type_attribute(
             ".snake_case_types",
-            "#[actix_prost_macros::serde(rename_all=\"snake_case\")]",
-        );
-
+            "#[actix_prost_macros::serde(rename_all = \"snake_case\")]",
+        )
+        .type_attribute(".serde_overrides", "#[actix_prost_macros::serde]");
     config.compile_protos(protos, includes)?;
     Ok(())
 }
@@ -51,6 +51,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "proto/errors.proto",
             "proto/conversions.proto",
             "proto/snake_case_types.proto",
+            "proto/serde_overrides.proto",
         ],
         &["proto/", "proto/googleapis", "proto/grpc-gateway"],
         gens,

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -24,16 +24,27 @@ fn compile(
         .protoc_arg("--openapiv2_out=proto")
         .protoc_arg("--openapiv2_opt")
         .protoc_arg("grpc_api_configuration=proto/http_api.yaml,output_format=yaml")
-        .type_attribute(".conversions", "#[actix_prost_macros::serde]")
-        .type_attribute(".errors", "#[actix_prost_macros::serde]")
-        .type_attribute(".rest", "#[actix_prost_macros::serde]")
-        .type_attribute(".simple", "#[actix_prost_macros::serde]")
-        .type_attribute(".types", "#[actix_prost_macros::serde]")
+        .type_attribute(".", "#[actix_prost_macros::serde]")
         .type_attribute(
             ".snake_case_types",
             "#[actix_prost_macros::serde(rename_all = \"snake_case\")]",
         )
-        .type_attribute(".serde_overrides", "#[actix_prost_macros::serde]");
+        .type_attribute(
+            ".serde_overrides.CamelCaseSimpleMessages",
+            "#[actix_prost_macros::serde(rename_all = \"camelCase\")]",
+        )
+        .type_attribute(
+            ".serde_overrides.SnakeCaseSimpleMessages",
+            "#[actix_prost_macros::serde(rename_all = \"snake_case\")]",
+        )
+        .type_attribute(
+            ".serde_overrides.CaseDependentOneOfs.CamelCaseValues",
+            "#[actix_prost_macros::serde(rename_all = \"camelCase\")]",
+        )
+        .type_attribute(
+            ".serde_overrides.CaseDependentOneOfs.snake_case_values",
+            "#[actix_prost_macros::serde(rename_all = \"snake_case\")]",
+        );
     config.compile_protos(protos, includes)?;
     Ok(())
 }

--- a/tests/proto/http_api.yaml
+++ b/tests/proto/http_api.yaml
@@ -75,3 +75,17 @@ http:
   - selector: "snake_case_types.SnakeCaseTypesRPC.OneOfsRPC"
     post: /snake-case-types/oneofs
     body: "*"
+
+  - selector: "serde_overrides.SerdeOverridesRPC.CamelCaseSimpleMessagesRPC"
+    post: /serde-overrides/camel-case-simple-messages
+    body: "*"
+  - selector: "serde_overrides.SerdeOverridesRPC.SnakeCaseSimpleMessagesRPC"
+    post: /serde-overrides/snake-case-simple-messages
+    body: "*"
+  - selector: "serde_overrides.SerdeOverridesRPC.UnspecifiedCaseSimpleMessagesRPC"
+    post: /serde-overrides/unspecified-case-simple-messages
+    body: "*"
+  - selector: "serde_overrides.SerdeOverridesRPC.CaseDependentOneOfsRPC"
+    post: /serde-overrides/case-dependent-oneofs
+    body: "*"
+

--- a/tests/proto/serde_overrides.proto
+++ b/tests/proto/serde_overrides.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+package serde_overrides;
+
+option go_package = "github.com/blockscout/actix-prost/tests";
+
+message CamelCaseSimpleMessages {
+  int64 long_name_field = 1;
+}
+
+message SnakeCaseSimpleMessages {
+  int64 long_name_field = 1;
+}
+
+message UnspecifiedCaseSimpleMessages {
+  int64 long_name_field = 1;
+}
+
+message CaseDependentOneOfs {
+  oneof camel_case_values {
+    int64 first_camel_case_value = 1;
+    int64 second_camel_case_value = 2;
+  }
+
+  oneof snake_case_values {
+    int64 first_snake_case_value = 3;
+    int64 second_snake_case_value = 4;
+  }
+
+  oneof unspecified_case_values {
+    int64 first_unspecified_case_value = 5;
+    int64 second_unspecified_case_value = 6;
+  }
+}
+
+service SerdeOverridesRPC {
+  rpc CamelCaseSimpleMessagesRPC(CamelCaseSimpleMessages) returns (CamelCaseSimpleMessages);
+  rpc SnakeCaseSimpleMessagesRPC(SnakeCaseSimpleMessages) returns (SnakeCaseSimpleMessages);
+  rpc UnspecifiedCaseSimpleMessagesRPC(UnspecifiedCaseSimpleMessages) returns (UnspecifiedCaseSimpleMessages);
+  rpc CaseDependentOneOfsRPC(CaseDependentOneOfs) returns (CaseDependentOneOfs);
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -21,3 +21,25 @@ mod conversions;
 
 #[cfg(test)]
 mod snake_case_types;
+
+#[cfg(test)]
+mod serde_overrides;
+
+#[cfg(test)]
+async fn assert_ping(addr: &std::net::SocketAddr, path: &str, body: String) {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://localhost:{}{}", addr.port(), path))
+        .body(body.clone())
+        .header("Content-Type", "application/json")
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let resp: serde_json::Value = serde_json::from_str(&resp)
+        .unwrap_or_else(|_| panic!("could not parse json, got: {}", resp));
+    pretty_assertions::assert_eq!(body, resp);
+}

--- a/tests/src/proto/convert_options.rs
+++ b/tests/src/proto/convert_options.rs
@@ -1,3 +1,4 @@
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConvertOptions {
@@ -10,6 +11,7 @@ pub struct ConvertOptions {
     #[prost(string, repeated, tag = "4")]
     pub attributes: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExtraFieldOptions {
@@ -18,6 +20,7 @@ pub struct ExtraFieldOptions {
     #[prost(string, tag = "2")]
     pub r#type: ::prost::alloc::string::String,
 }
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeriveOptions {

--- a/tests/src/proto/google.protobuf.rs
+++ b/tests/src/proto/google.protobuf.rs
@@ -88,6 +88,7 @@
 /// <http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime(>)
 /// ) to obtain a formatter capable of generating timestamps in this format.
 ///
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Timestamp {
@@ -189,6 +190,7 @@ pub struct Timestamp {
 ///        "value": "1.212s"
 ///      }
 ///
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Any {
@@ -229,6 +231,7 @@ pub struct Any {
 }
 /// The protocol compiler can output a FileDescriptorSet containing the .proto
 /// files it parses.
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileDescriptorSet {
@@ -236,6 +239,7 @@ pub struct FileDescriptorSet {
     pub file: ::prost::alloc::vec::Vec<FileDescriptorProto>,
 }
 /// Describes a complete .proto file.
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileDescriptorProto {
@@ -283,6 +287,7 @@ pub struct FileDescriptorProto {
     pub edition: ::core::option::Option<i32>,
 }
 /// Describes a message type.
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DescriptorProto {
@@ -311,6 +316,7 @@ pub struct DescriptorProto {
 }
 /// Nested message and enum types in `DescriptorProto`.
 pub mod descriptor_proto {
+    #[actix_prost_macros::serde]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ExtensionRange {
@@ -326,6 +332,7 @@ pub mod descriptor_proto {
     /// Range of reserved tag numbers. Reserved tag numbers may not be used by
     /// fields or extension ranges in the same message. Reserved ranges may
     /// not overlap.
+    #[actix_prost_macros::serde]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ReservedRange {
@@ -337,6 +344,7 @@ pub mod descriptor_proto {
         pub end: ::core::option::Option<i32>,
     }
 }
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExtensionRangeOptions {
@@ -364,6 +372,7 @@ pub struct ExtensionRangeOptions {
 }
 /// Nested message and enum types in `ExtensionRangeOptions`.
 pub mod extension_range_options {
+    #[actix_prost_macros::serde]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Declaration {
@@ -390,6 +399,7 @@ pub mod extension_range_options {
         pub repeated: ::core::option::Option<bool>,
     }
     /// The verification state of the extension range.
+    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -429,6 +439,7 @@ pub mod extension_range_options {
     }
 }
 /// Describes a field within a message.
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldDescriptorProto {
@@ -497,6 +508,7 @@ pub struct FieldDescriptorProto {
 }
 /// Nested message and enum types in `FieldDescriptorProto`.
 pub mod field_descriptor_proto {
+    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -596,6 +608,7 @@ pub mod field_descriptor_proto {
             }
         }
     }
+    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -641,6 +654,7 @@ pub mod field_descriptor_proto {
     }
 }
 /// Describes a oneof.
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OneofDescriptorProto {
@@ -650,6 +664,7 @@ pub struct OneofDescriptorProto {
     pub options: ::core::option::Option<OneofOptions>,
 }
 /// Describes an enum type.
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumDescriptorProto {
@@ -679,6 +694,7 @@ pub mod enum_descriptor_proto {
     /// Note that this is distinct from DescriptorProto.ReservedRange in that it
     /// is inclusive such that it can appropriately represent the entire int32
     /// domain.
+    #[actix_prost_macros::serde]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct EnumReservedRange {
@@ -691,6 +707,7 @@ pub mod enum_descriptor_proto {
     }
 }
 /// Describes a value within an enum.
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumValueDescriptorProto {
@@ -702,6 +719,7 @@ pub struct EnumValueDescriptorProto {
     pub options: ::core::option::Option<EnumValueOptions>,
 }
 /// Describes a service.
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServiceDescriptorProto {
@@ -713,6 +731,7 @@ pub struct ServiceDescriptorProto {
     pub options: ::core::option::Option<ServiceOptions>,
 }
 /// Describes a method of a service.
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MethodDescriptorProto {
@@ -733,6 +752,7 @@ pub struct MethodDescriptorProto {
     #[prost(bool, optional, tag = "6", default = "false")]
     pub server_streaming: ::core::option::Option<bool>,
 }
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileOptions {
@@ -856,6 +876,7 @@ pub struct FileOptions {
 /// Nested message and enum types in `FileOptions`.
 pub mod file_options {
     /// Generated classes can be optimized for speed or code size.
+    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -901,6 +922,7 @@ pub mod file_options {
         }
     }
 }
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MessageOptions {
@@ -978,6 +1000,7 @@ pub struct MessageOptions {
     #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldOptions {
@@ -1085,6 +1108,7 @@ pub struct FieldOptions {
 }
 /// Nested message and enum types in `FieldOptions`.
 pub mod field_options {
+    #[actix_prost_macros::serde]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct EditionDefault {
@@ -1095,6 +1119,7 @@ pub mod field_options {
         pub value: ::core::option::Option<::prost::alloc::string::String>,
     }
     /// Information about the support window of a feature.
+    #[actix_prost_macros::serde]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct FeatureSupport {
@@ -1117,6 +1142,7 @@ pub mod field_options {
         #[prost(enumeration = "super::Edition", optional, tag = "4")]
         pub edition_removed: ::core::option::Option<i32>,
     }
+    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1163,6 +1189,7 @@ pub mod field_options {
             }
         }
     }
+    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1208,6 +1235,7 @@ pub mod field_options {
     /// If set to RETENTION_SOURCE, the option will be omitted from the binary.
     /// Note: as of January 2023, support for this is in progress and does not yet
     /// have an effect (b/264593489).
+    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1251,6 +1279,7 @@ pub mod field_options {
     /// as an option. If it is unset, then the field may be freely used as an
     /// option on any kind of entity. Note: as of January 2023, support for this is
     /// in progress and does not yet have an effect (b/264593489).
+    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1314,6 +1343,7 @@ pub mod field_options {
         }
     }
 }
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OneofOptions {
@@ -1324,6 +1354,7 @@ pub struct OneofOptions {
     #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumOptions {
@@ -1353,6 +1384,7 @@ pub struct EnumOptions {
     #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumValueOptions {
@@ -1377,6 +1409,7 @@ pub struct EnumValueOptions {
     #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServiceOptions {
@@ -1393,6 +1426,7 @@ pub struct ServiceOptions {
     #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MethodOptions {
@@ -1421,6 +1455,7 @@ pub mod method_options {
     /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
     /// or neither? HTTP based RPC implementation may choose GET verb for safe
     /// methods, and PUT verb for idempotent methods instead of the default POST.
+    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1469,6 +1504,7 @@ pub mod method_options {
 /// options protos in descriptor objects (e.g. returned by Descriptor::options(),
 /// or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
 /// in them.
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UninterpretedOption {
@@ -1496,6 +1532,7 @@ pub mod uninterpreted_option {
     /// extension (denoted with parentheses in options specs in .proto files).
     /// E.g.,{ ["foo", false], ["bar.baz", true], ["moo", false] } represents
     /// "foo.(bar.baz).moo".
+    #[actix_prost_macros::serde]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NamePart {
@@ -1511,6 +1548,7 @@ pub mod uninterpreted_option {
 /// readability, but leave us very open to this scenario.  A future feature will
 /// be designed and implemented to handle this, hopefully before we ever hit a
 /// conflict here.
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FeatureSet {
@@ -1529,6 +1567,7 @@ pub struct FeatureSet {
 }
 /// Nested message and enum types in `FeatureSet`.
 pub mod feature_set {
+    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1571,6 +1610,7 @@ pub mod feature_set {
             }
         }
     }
+    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1610,6 +1650,7 @@ pub mod feature_set {
             }
         }
     }
+    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1649,6 +1690,7 @@ pub mod feature_set {
             }
         }
     }
+    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1688,6 +1730,7 @@ pub mod feature_set {
             }
         }
     }
+    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1727,6 +1770,7 @@ pub mod feature_set {
             }
         }
     }
+    #[actix_prost_macros::serde]
     #[derive(
         Clone,
         Copy,
@@ -1771,6 +1815,7 @@ pub mod feature_set {
 /// messages are generated from FeatureSet extensions and can be used to seed
 /// feature resolution. The resolution with this object becomes a simple search
 /// for the closest matching edition, followed by proto merges.
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FeatureSetDefaults {
@@ -1793,6 +1838,7 @@ pub mod feature_set_defaults {
     /// defaults. Not all editions may be contained here.  For a given edition,
     /// the defaults at the closest matching edition ordered at or before it should
     /// be used.  This field must be in strict ascending order by edition.
+    #[actix_prost_macros::serde]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct FeatureSetEditionDefault {
@@ -1808,6 +1854,7 @@ pub mod feature_set_defaults {
 }
 /// Encapsulates information about the original source file from which a
 /// FileDescriptorProto was generated.
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SourceCodeInfo {
@@ -1859,6 +1906,7 @@ pub struct SourceCodeInfo {
 }
 /// Nested message and enum types in `SourceCodeInfo`.
 pub mod source_code_info {
+    #[actix_prost_macros::serde]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Location {
@@ -1954,6 +2002,7 @@ pub mod source_code_info {
 /// Describes the relationship between generated code and its original source
 /// file. A GeneratedCodeInfo message is associated with only one generated
 /// source file, but may contain references to different source .proto files.
+#[actix_prost_macros::serde]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GeneratedCodeInfo {
@@ -1964,6 +2013,7 @@ pub struct GeneratedCodeInfo {
 }
 /// Nested message and enum types in `GeneratedCodeInfo`.
 pub mod generated_code_info {
+    #[actix_prost_macros::serde]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Annotation {
@@ -1990,6 +2040,7 @@ pub mod generated_code_info {
     pub mod annotation {
         /// Represents the identified object's effect on the element in the original
         /// .proto file.
+        #[actix_prost_macros::serde]
         #[derive(
             Clone,
             Copy,
@@ -2035,6 +2086,7 @@ pub mod generated_code_info {
     }
 }
 /// The full set of known editions.
+#[actix_prost_macros::serde]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum Edition {

--- a/tests/src/proto/mod.rs
+++ b/tests/src/proto/mod.rs
@@ -1,6 +1,7 @@
 pub mod conversions;
 pub mod errors;
 pub mod rest;
+pub mod serde_overrides;
 pub mod simple;
 pub mod snake_case_types;
 pub mod types;

--- a/tests/src/proto/serde_overrides.rs
+++ b/tests/src/proto/serde_overrides.rs
@@ -1,0 +1,767 @@
+#[actix_prost_macros::serde]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CamelCaseSimpleMessages {
+    #[prost(int64, tag = "1")]
+    pub long_name_field: i64,
+}
+#[actix_prost_macros::serde]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SnakeCaseSimpleMessages {
+    #[prost(int64, tag = "1")]
+    pub long_name_field: i64,
+}
+#[actix_prost_macros::serde]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UnspecifiedCaseSimpleMessages {
+    #[prost(int64, tag = "1")]
+    pub long_name_field: i64,
+}
+#[actix_prost_macros::serde]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CaseDependentOneOfs {
+    #[prost(oneof = "case_dependent_one_ofs::CamelCaseValues", tags = "1, 2")]
+    pub camel_case_values: ::core::option::Option<
+        case_dependent_one_ofs::CamelCaseValues,
+    >,
+    #[prost(oneof = "case_dependent_one_ofs::SnakeCaseValues", tags = "3, 4")]
+    pub snake_case_values: ::core::option::Option<
+        case_dependent_one_ofs::SnakeCaseValues,
+    >,
+    #[prost(oneof = "case_dependent_one_ofs::UnspecifiedCaseValues", tags = "5, 6")]
+    pub unspecified_case_values: ::core::option::Option<
+        case_dependent_one_ofs::UnspecifiedCaseValues,
+    >,
+}
+/// Nested message and enum types in `CaseDependentOneOfs`.
+pub mod case_dependent_one_ofs {
+    #[actix_prost_macros::serde]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum CamelCaseValues {
+        #[prost(int64, tag = "1")]
+        FirstCamelCaseValue(i64),
+        #[prost(int64, tag = "2")]
+        SecondCamelCaseValue(i64),
+    }
+    #[actix_prost_macros::serde]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum SnakeCaseValues {
+        #[prost(int64, tag = "3")]
+        FirstSnakeCaseValue(i64),
+        #[prost(int64, tag = "4")]
+        SecondSnakeCaseValue(i64),
+    }
+    #[actix_prost_macros::serde]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum UnspecifiedCaseValues {
+        #[prost(int64, tag = "5")]
+        FirstUnspecifiedCaseValue(i64),
+        #[prost(int64, tag = "6")]
+        SecondUnspecifiedCaseValue(i64),
+    }
+}
+pub mod serde_overrides_rpc_actix {
+    #![allow(unused_variables, dead_code, missing_docs)]
+    use super::*;
+    use super::serde_overrides_rpc_server::SerdeOverridesRpc;
+    use std::sync::Arc;
+    #[actix_prost_macros::serde]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct CamelCaseSimpleMessagesRPCJson {
+        #[prost(int64, tag = "1")]
+        pub long_name_field: i64,
+    }
+    #[actix_prost_macros::serde]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct SnakeCaseSimpleMessagesRPCJson {
+        #[prost(int64, tag = "1")]
+        pub long_name_field: i64,
+    }
+    #[actix_prost_macros::serde]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct UnspecifiedCaseSimpleMessagesRPCJson {
+        #[prost(int64, tag = "1")]
+        pub long_name_field: i64,
+    }
+    #[actix_prost_macros::serde]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct CaseDependentOneOfsRPCJson {
+        #[prost(oneof = "case_dependent_one_ofs::CamelCaseValues", tags = "1, 2")]
+        pub camel_case_values: ::core::option::Option<
+            case_dependent_one_ofs::CamelCaseValues,
+        >,
+        #[prost(oneof = "case_dependent_one_ofs::SnakeCaseValues", tags = "3, 4")]
+        pub snake_case_values: ::core::option::Option<
+            case_dependent_one_ofs::SnakeCaseValues,
+        >,
+        #[prost(oneof = "case_dependent_one_ofs::UnspecifiedCaseValues", tags = "5, 6")]
+        pub unspecified_case_values: ::core::option::Option<
+            case_dependent_one_ofs::UnspecifiedCaseValues,
+        >,
+    }
+    async fn call_camel_case_simple_messages_rpc(
+        service: ::actix_web::web::Data<dyn SerdeOverridesRpc + Sync + Send + 'static>,
+        http_request: ::actix_web::HttpRequest,
+        payload: ::actix_web::web::Payload,
+    ) -> Result<::actix_web::web::Json<CamelCaseSimpleMessages>, ::actix_prost::Error> {
+        let mut payload = payload.into_inner();
+        let json = <::actix_web::web::Json<
+            CamelCaseSimpleMessagesRPCJson,
+        > as ::actix_web::FromRequest>::from_request(&http_request, &mut payload)
+            .await
+            .map_err(|err| ::actix_prost::Error::from_actix(
+                err,
+                ::tonic::Code::InvalidArgument,
+            ))?
+            .into_inner();
+        let request = CamelCaseSimpleMessages {
+            long_name_field: json.long_name_field,
+        };
+        let request = ::actix_prost::new_request(request, &http_request);
+        let response = service.camel_case_simple_messages_rpc(request).await?;
+        let response = response.into_inner();
+        Ok(::actix_web::web::Json(response))
+    }
+    async fn call_snake_case_simple_messages_rpc(
+        service: ::actix_web::web::Data<dyn SerdeOverridesRpc + Sync + Send + 'static>,
+        http_request: ::actix_web::HttpRequest,
+        payload: ::actix_web::web::Payload,
+    ) -> Result<::actix_web::web::Json<SnakeCaseSimpleMessages>, ::actix_prost::Error> {
+        let mut payload = payload.into_inner();
+        let json = <::actix_web::web::Json<
+            SnakeCaseSimpleMessagesRPCJson,
+        > as ::actix_web::FromRequest>::from_request(&http_request, &mut payload)
+            .await
+            .map_err(|err| ::actix_prost::Error::from_actix(
+                err,
+                ::tonic::Code::InvalidArgument,
+            ))?
+            .into_inner();
+        let request = SnakeCaseSimpleMessages {
+            long_name_field: json.long_name_field,
+        };
+        let request = ::actix_prost::new_request(request, &http_request);
+        let response = service.snake_case_simple_messages_rpc(request).await?;
+        let response = response.into_inner();
+        Ok(::actix_web::web::Json(response))
+    }
+    async fn call_unspecified_case_simple_messages_rpc(
+        service: ::actix_web::web::Data<dyn SerdeOverridesRpc + Sync + Send + 'static>,
+        http_request: ::actix_web::HttpRequest,
+        payload: ::actix_web::web::Payload,
+    ) -> Result<
+        ::actix_web::web::Json<UnspecifiedCaseSimpleMessages>,
+        ::actix_prost::Error,
+    > {
+        let mut payload = payload.into_inner();
+        let json = <::actix_web::web::Json<
+            UnspecifiedCaseSimpleMessagesRPCJson,
+        > as ::actix_web::FromRequest>::from_request(&http_request, &mut payload)
+            .await
+            .map_err(|err| ::actix_prost::Error::from_actix(
+                err,
+                ::tonic::Code::InvalidArgument,
+            ))?
+            .into_inner();
+        let request = UnspecifiedCaseSimpleMessages {
+            long_name_field: json.long_name_field,
+        };
+        let request = ::actix_prost::new_request(request, &http_request);
+        let response = service.unspecified_case_simple_messages_rpc(request).await?;
+        let response = response.into_inner();
+        Ok(::actix_web::web::Json(response))
+    }
+    async fn call_case_dependent_one_ofs_rpc(
+        service: ::actix_web::web::Data<dyn SerdeOverridesRpc + Sync + Send + 'static>,
+        http_request: ::actix_web::HttpRequest,
+        payload: ::actix_web::web::Payload,
+    ) -> Result<::actix_web::web::Json<CaseDependentOneOfs>, ::actix_prost::Error> {
+        let mut payload = payload.into_inner();
+        let json = <::actix_web::web::Json<
+            CaseDependentOneOfsRPCJson,
+        > as ::actix_web::FromRequest>::from_request(&http_request, &mut payload)
+            .await
+            .map_err(|err| ::actix_prost::Error::from_actix(
+                err,
+                ::tonic::Code::InvalidArgument,
+            ))?
+            .into_inner();
+        let request = CaseDependentOneOfs {
+            camel_case_values: json.camel_case_values,
+            snake_case_values: json.snake_case_values,
+            unspecified_case_values: json.unspecified_case_values,
+        };
+        let request = ::actix_prost::new_request(request, &http_request);
+        let response = service.case_dependent_one_ofs_rpc(request).await?;
+        let response = response.into_inner();
+        Ok(::actix_web::web::Json(response))
+    }
+    pub fn route_serde_overrides_rpc(
+        config: &mut ::actix_web::web::ServiceConfig,
+        service: Arc<dyn SerdeOverridesRpc + Send + Sync + 'static>,
+    ) {
+        config.app_data(::actix_web::web::Data::from(service));
+        config
+            .route(
+                "/serde-overrides/camel-case-simple-messages",
+                ::actix_web::web::post().to(call_camel_case_simple_messages_rpc),
+            );
+        config
+            .route(
+                "/serde-overrides/snake-case-simple-messages",
+                ::actix_web::web::post().to(call_snake_case_simple_messages_rpc),
+            );
+        config
+            .route(
+                "/serde-overrides/unspecified-case-simple-messages",
+                ::actix_web::web::post().to(call_unspecified_case_simple_messages_rpc),
+            );
+        config
+            .route(
+                "/serde-overrides/case-dependent-oneofs",
+                ::actix_web::web::post().to(call_case_dependent_one_ofs_rpc),
+            );
+    }
+}
+#[derive(Clone, Debug)]
+pub struct CamelCaseSimpleMessagesInternal {
+    pub long_name_field: i64,
+}
+impl convert_trait::TryConvert<CamelCaseSimpleMessages>
+for CamelCaseSimpleMessagesInternal {
+    fn try_convert(from: CamelCaseSimpleMessages) -> Result<Self, String> {
+        Ok(Self {
+            long_name_field: from.long_name_field,
+        })
+    }
+}
+impl convert_trait::TryConvert<CamelCaseSimpleMessagesInternal>
+for CamelCaseSimpleMessages {
+    fn try_convert(from: CamelCaseSimpleMessagesInternal) -> Result<Self, String> {
+        Ok(Self {
+            long_name_field: from.long_name_field,
+        })
+    }
+}
+#[derive(Clone, Debug)]
+pub struct SnakeCaseSimpleMessagesInternal {
+    pub long_name_field: i64,
+}
+impl convert_trait::TryConvert<SnakeCaseSimpleMessages>
+for SnakeCaseSimpleMessagesInternal {
+    fn try_convert(from: SnakeCaseSimpleMessages) -> Result<Self, String> {
+        Ok(Self {
+            long_name_field: from.long_name_field,
+        })
+    }
+}
+impl convert_trait::TryConvert<SnakeCaseSimpleMessagesInternal>
+for SnakeCaseSimpleMessages {
+    fn try_convert(from: SnakeCaseSimpleMessagesInternal) -> Result<Self, String> {
+        Ok(Self {
+            long_name_field: from.long_name_field,
+        })
+    }
+}
+#[derive(Clone, Debug)]
+pub struct UnspecifiedCaseSimpleMessagesInternal {
+    pub long_name_field: i64,
+}
+impl convert_trait::TryConvert<UnspecifiedCaseSimpleMessages>
+for UnspecifiedCaseSimpleMessagesInternal {
+    fn try_convert(from: UnspecifiedCaseSimpleMessages) -> Result<Self, String> {
+        Ok(Self {
+            long_name_field: from.long_name_field,
+        })
+    }
+}
+impl convert_trait::TryConvert<UnspecifiedCaseSimpleMessagesInternal>
+for UnspecifiedCaseSimpleMessages {
+    fn try_convert(from: UnspecifiedCaseSimpleMessagesInternal) -> Result<Self, String> {
+        Ok(Self {
+            long_name_field: from.long_name_field,
+        })
+    }
+}
+#[derive(Clone, Debug)]
+pub struct CaseDependentOneOfsInternal {
+    pub camel_case_values: ::core::option::Option<
+        case_dependent_one_ofs::CamelCaseValues,
+    >,
+    pub snake_case_values: ::core::option::Option<
+        case_dependent_one_ofs::SnakeCaseValues,
+    >,
+    pub unspecified_case_values: ::core::option::Option<
+        case_dependent_one_ofs::UnspecifiedCaseValues,
+    >,
+}
+impl convert_trait::TryConvert<CaseDependentOneOfs> for CaseDependentOneOfsInternal {
+    fn try_convert(from: CaseDependentOneOfs) -> Result<Self, String> {
+        Ok(Self {
+            camel_case_values: from.camel_case_values,
+            snake_case_values: from.snake_case_values,
+            unspecified_case_values: from.unspecified_case_values,
+        })
+    }
+}
+impl convert_trait::TryConvert<CaseDependentOneOfsInternal> for CaseDependentOneOfs {
+    fn try_convert(from: CaseDependentOneOfsInternal) -> Result<Self, String> {
+        Ok(Self {
+            camel_case_values: from.camel_case_values,
+            snake_case_values: from.snake_case_values,
+            unspecified_case_values: from.unspecified_case_values,
+        })
+    }
+}
+/// Generated client implementations.
+pub mod serde_overrides_rpc_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct SerdeOverridesRpcClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl SerdeOverridesRpcClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> SerdeOverridesRpcClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> SerdeOverridesRpcClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            SerdeOverridesRpcClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        pub async fn camel_case_simple_messages_rpc(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CamelCaseSimpleMessages>,
+        ) -> Result<tonic::Response<super::CamelCaseSimpleMessages>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/serde_overrides.SerdeOverridesRPC/CamelCaseSimpleMessagesRPC",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn snake_case_simple_messages_rpc(
+            &mut self,
+            request: impl tonic::IntoRequest<super::SnakeCaseSimpleMessages>,
+        ) -> Result<tonic::Response<super::SnakeCaseSimpleMessages>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/serde_overrides.SerdeOverridesRPC/SnakeCaseSimpleMessagesRPC",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn unspecified_case_simple_messages_rpc(
+            &mut self,
+            request: impl tonic::IntoRequest<super::UnspecifiedCaseSimpleMessages>,
+        ) -> Result<
+            tonic::Response<super::UnspecifiedCaseSimpleMessages>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/serde_overrides.SerdeOverridesRPC/UnspecifiedCaseSimpleMessagesRPC",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn case_dependent_one_ofs_rpc(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CaseDependentOneOfs>,
+        ) -> Result<tonic::Response<super::CaseDependentOneOfs>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/serde_overrides.SerdeOverridesRPC/CaseDependentOneOfsRPC",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+pub mod serde_overrides_rpc_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with SerdeOverridesRpcServer.
+    #[async_trait]
+    pub trait SerdeOverridesRpc: Send + Sync + 'static {
+        async fn camel_case_simple_messages_rpc(
+            &self,
+            request: tonic::Request<super::CamelCaseSimpleMessages>,
+        ) -> Result<tonic::Response<super::CamelCaseSimpleMessages>, tonic::Status>;
+        async fn snake_case_simple_messages_rpc(
+            &self,
+            request: tonic::Request<super::SnakeCaseSimpleMessages>,
+        ) -> Result<tonic::Response<super::SnakeCaseSimpleMessages>, tonic::Status>;
+        async fn unspecified_case_simple_messages_rpc(
+            &self,
+            request: tonic::Request<super::UnspecifiedCaseSimpleMessages>,
+        ) -> Result<
+            tonic::Response<super::UnspecifiedCaseSimpleMessages>,
+            tonic::Status,
+        >;
+        async fn case_dependent_one_ofs_rpc(
+            &self,
+            request: tonic::Request<super::CaseDependentOneOfs>,
+        ) -> Result<tonic::Response<super::CaseDependentOneOfs>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct SerdeOverridesRpcServer<T: SerdeOverridesRpc> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: SerdeOverridesRpc> SerdeOverridesRpcServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for SerdeOverridesRpcServer<T>
+    where
+        T: SerdeOverridesRpc,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/serde_overrides.SerdeOverridesRPC/CamelCaseSimpleMessagesRPC" => {
+                    #[allow(non_camel_case_types)]
+                    struct CamelCaseSimpleMessagesRPCSvc<T: SerdeOverridesRpc>(
+                        pub Arc<T>,
+                    );
+                    impl<
+                        T: SerdeOverridesRpc,
+                    > tonic::server::UnaryService<super::CamelCaseSimpleMessages>
+                    for CamelCaseSimpleMessagesRPCSvc<T> {
+                        type Response = super::CamelCaseSimpleMessages;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::CamelCaseSimpleMessages>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).camel_case_simple_messages_rpc(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = CamelCaseSimpleMessagesRPCSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/serde_overrides.SerdeOverridesRPC/SnakeCaseSimpleMessagesRPC" => {
+                    #[allow(non_camel_case_types)]
+                    struct SnakeCaseSimpleMessagesRPCSvc<T: SerdeOverridesRpc>(
+                        pub Arc<T>,
+                    );
+                    impl<
+                        T: SerdeOverridesRpc,
+                    > tonic::server::UnaryService<super::SnakeCaseSimpleMessages>
+                    for SnakeCaseSimpleMessagesRPCSvc<T> {
+                        type Response = super::SnakeCaseSimpleMessages;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::SnakeCaseSimpleMessages>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).snake_case_simple_messages_rpc(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = SnakeCaseSimpleMessagesRPCSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/serde_overrides.SerdeOverridesRPC/UnspecifiedCaseSimpleMessagesRPC" => {
+                    #[allow(non_camel_case_types)]
+                    struct UnspecifiedCaseSimpleMessagesRPCSvc<T: SerdeOverridesRpc>(
+                        pub Arc<T>,
+                    );
+                    impl<
+                        T: SerdeOverridesRpc,
+                    > tonic::server::UnaryService<super::UnspecifiedCaseSimpleMessages>
+                    for UnspecifiedCaseSimpleMessagesRPCSvc<T> {
+                        type Response = super::UnspecifiedCaseSimpleMessages;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::UnspecifiedCaseSimpleMessages>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).unspecified_case_simple_messages_rpc(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = UnspecifiedCaseSimpleMessagesRPCSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/serde_overrides.SerdeOverridesRPC/CaseDependentOneOfsRPC" => {
+                    #[allow(non_camel_case_types)]
+                    struct CaseDependentOneOfsRPCSvc<T: SerdeOverridesRpc>(pub Arc<T>);
+                    impl<
+                        T: SerdeOverridesRpc,
+                    > tonic::server::UnaryService<super::CaseDependentOneOfs>
+                    for CaseDependentOneOfsRPCSvc<T> {
+                        type Response = super::CaseDependentOneOfs;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::CaseDependentOneOfs>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).case_dependent_one_ofs_rpc(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = CaseDependentOneOfsRPCSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: SerdeOverridesRpc> Clone for SerdeOverridesRpcServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
+        }
+    }
+    impl<T: SerdeOverridesRpc> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: SerdeOverridesRpc> tonic::server::NamedService
+    for SerdeOverridesRpcServer<T> {
+        const NAME: &'static str = "serde_overrides.SerdeOverridesRPC";
+    }
+}

--- a/tests/src/proto/serde_overrides.rs
+++ b/tests/src/proto/serde_overrides.rs
@@ -1,4 +1,5 @@
 #[actix_prost_macros::serde]
+#[actix_prost_macros::serde(rename_all = "camelCase")]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CamelCaseSimpleMessages {
@@ -6,6 +7,7 @@ pub struct CamelCaseSimpleMessages {
     pub long_name_field: i64,
 }
 #[actix_prost_macros::serde]
+#[actix_prost_macros::serde(rename_all = "snake_case")]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SnakeCaseSimpleMessages {
@@ -48,6 +50,7 @@ pub mod case_dependent_one_ofs {
         SecondCamelCaseValue(i64),
     }
     #[actix_prost_macros::serde]
+    #[actix_prost_macros::serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum SnakeCaseValues {
@@ -72,6 +75,7 @@ pub mod serde_overrides_rpc_actix {
     use super::serde_overrides_rpc_server::SerdeOverridesRpc;
     use std::sync::Arc;
     #[actix_prost_macros::serde]
+    #[actix_prost_macros::serde(rename_all = "camelCase")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct CamelCaseSimpleMessagesRPCJson {
@@ -79,6 +83,7 @@ pub mod serde_overrides_rpc_actix {
         pub long_name_field: i64,
     }
     #[actix_prost_macros::serde]
+    #[actix_prost_macros::serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct SnakeCaseSimpleMessagesRPCJson {

--- a/tests/src/proto/snake_case_types.rs
+++ b/tests/src/proto/snake_case_types.rs
@@ -1,3 +1,4 @@
+#[actix_prost_macros::serde]
 #[actix_prost_macros::serde(rename_all = "snake_case")]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -5,6 +6,7 @@ pub struct SimpleMessages {
     #[prost(int64, tag = "1")]
     pub long_name_field: i64,
 }
+#[actix_prost_macros::serde]
 #[actix_prost_macros::serde(rename_all = "snake_case")]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -14,6 +16,7 @@ pub struct OneOfs {
 }
 /// Nested message and enum types in `OneOfs`.
 pub mod one_ofs {
+    #[actix_prost_macros::serde]
     #[actix_prost_macros::serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -29,6 +32,7 @@ pub mod snake_case_types_rpc_actix {
     use super::*;
     use super::snake_case_types_rpc_server::SnakeCaseTypesRpc;
     use std::sync::Arc;
+    #[actix_prost_macros::serde]
     #[actix_prost_macros::serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -36,6 +40,7 @@ pub mod snake_case_types_rpc_actix {
         #[prost(int64, tag = "1")]
         pub long_name_field: i64,
     }
+    #[actix_prost_macros::serde]
     #[actix_prost_macros::serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]

--- a/tests/src/serde_overrides.rs
+++ b/tests/src/serde_overrides.rs
@@ -1,0 +1,84 @@
+use crate::{
+    assert_ping,
+    proto::serde_overrides::{
+        serde_overrides_rpc_actix::route_serde_overrides_rpc,
+        serde_overrides_rpc_server::SerdeOverridesRpc, CamelCaseSimpleMessages,
+        CaseDependentOneOfs, SnakeCaseSimpleMessages, UnspecifiedCaseSimpleMessages,
+    },
+    test,
+};
+use actix_web::{App, HttpServer};
+use std::{net::SocketAddr, sync::Arc};
+use tonic::{Request, Response, Status};
+
+#[derive(Default)]
+struct SerdeOverridesServer {}
+
+#[async_trait::async_trait]
+impl SerdeOverridesRpc for SerdeOverridesServer {
+    async fn snake_case_simple_messages_rpc(
+        &self,
+        request: Request<SnakeCaseSimpleMessages>,
+    ) -> Result<Response<SnakeCaseSimpleMessages>, Status> {
+        Ok(Response::new(request.into_inner()))
+    }
+
+    async fn camel_case_simple_messages_rpc(
+        &self,
+        request: Request<CamelCaseSimpleMessages>,
+    ) -> Result<Response<CamelCaseSimpleMessages>, Status> {
+        Ok(Response::new(request.into_inner()))
+    }
+
+    async fn unspecified_case_simple_messages_rpc(
+        &self,
+        request: Request<UnspecifiedCaseSimpleMessages>,
+    ) -> Result<Response<UnspecifiedCaseSimpleMessages>, Status> {
+        Ok(Response::new(request.into_inner()))
+    }
+
+    async fn case_dependent_one_ofs_rpc(
+        &self,
+        request: Request<CaseDependentOneOfs>,
+    ) -> Result<Response<CaseDependentOneOfs>, Status> {
+        Ok(Response::new(request.into_inner()))
+    }
+}
+
+#[tokio::test]
+async fn ping() {
+    let server = Arc::new(SerdeOverridesServer::default());
+    let addr: SocketAddr = test::get_test_addr();
+    let http = HttpServer::new(move || {
+        App::new().configure(|config| route_serde_overrides_rpc(config, server.clone()))
+    })
+    .bind(addr)
+    .unwrap();
+
+    tokio::spawn(http.run());
+
+    assert_ping(
+        &addr,
+        "/serde-overrides/camel-case-simple-messages",
+        r#"{ "longNameField": "42" }"#.into(),
+    )
+    .await;
+    assert_ping(
+        &addr,
+        "/serde-overrides/snake-case-simple-messages",
+        r#"{ "long_name_field": "42" }"#.into(),
+    )
+    .await;
+    assert_ping(
+        &addr,
+        "/serde-overrides/unspecified-case-simple-messages",
+        r#"{ "longNameField": "42" }"#.into(),
+    )
+    .await;
+    assert_ping(
+        &addr,
+        "/serde-overrides/case-dependent-oneofs",
+        r#"{ "firstCamelCaseValue": "43", "first_snake_case_value": "42", "firstUnspecifiedCaseValue": "44" }"#.into(),
+    )
+    .await;
+}

--- a/tests/src/snake_case_types.rs
+++ b/tests/src/snake_case_types.rs
@@ -1,4 +1,5 @@
 use crate::{
+    assert_ping,
     proto::snake_case_types::{
         snake_case_types_rpc_actix::route_snake_case_types_rpc,
         snake_case_types_rpc_server::SnakeCaseTypesRpc, OneOfs, SimpleMessages,
@@ -6,7 +7,6 @@ use crate::{
     test,
 };
 use actix_web::{App, HttpServer};
-use pretty_assertions::assert_eq;
 use std::{net::SocketAddr, sync::Arc};
 use tonic::{Request, Response, Status};
 
@@ -25,24 +25,6 @@ impl SnakeCaseTypesRpc for SnakeCaseTypesServer {
     async fn one_ofs_rpc(&self, request: Request<OneOfs>) -> Result<Response<OneOfs>, Status> {
         Ok(Response::new(request.into_inner()))
     }
-}
-
-async fn assert_ping(addr: &SocketAddr, path: &str, body: String) {
-    let client = reqwest::Client::new();
-    let resp = client
-        .post(format!("http://localhost:{}{}", addr.port(), path))
-        .body(body.clone())
-        .header("Content-Type", "application/json")
-        .send()
-        .await
-        .unwrap()
-        .text()
-        .await
-        .unwrap();
-    let body: serde_json::Value = serde_json::from_str(&body).unwrap();
-    let resp: serde_json::Value = serde_json::from_str(&resp)
-        .unwrap_or_else(|_| panic!("could not parse json, got: {}", resp));
-    assert_eq!(body, resp);
 }
 
 #[tokio::test]

--- a/tests/src/types.rs
+++ b/tests/src/types.rs
@@ -1,4 +1,5 @@
 use crate::{
+    assert_ping,
     proto::types::{
         types_rpc_actix::route_types_rpc, types_rpc_server::TypesRpc, Complex, Enums, Maps, OneOfs,
         OptionalScalars, Repeated, Scalars,
@@ -6,7 +7,6 @@ use crate::{
     test,
 };
 use actix_web::{App, HttpServer};
-use pretty_assertions::assert_eq;
 use std::{net::SocketAddr, sync::Arc};
 use tonic::{Request, Response, Status};
 
@@ -39,24 +39,6 @@ impl TypesRpc for TypesServer {
     async fn complex_rpc(&self, request: Request<Complex>) -> Result<Response<Complex>, Status> {
         Ok(Response::new(request.into_inner()))
     }
-}
-
-async fn assert_ping(addr: &SocketAddr, path: &str, body: String) {
-    let client = reqwest::Client::new();
-    let resp = client
-        .post(format!("http://localhost:{}{}", addr.port(), path))
-        .body(body.clone())
-        .header("Content-Type", "application/json")
-        .send()
-        .await
-        .unwrap()
-        .text()
-        .await
-        .unwrap();
-    let body: serde_json::Value = serde_json::from_str(&body).unwrap();
-    let resp: serde_json::Value = serde_json::from_str(&resp)
-        .unwrap_or_else(|_| panic!("could not parse json, got: {}", resp));
-    assert_eq!(body, resp);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Add the ability to specify several serde macros definitions for any given type, which allows to specify a default case value for all types except some subset, for which this value is overwritten. Uses the latest specifying case value for any given type.