### PR TITLE
fix: correct datetime serialize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/blockscout/actix-prost"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ repository = "https://github.com/blockscout/actix-prost"
 exclude = ["tests"]
 
 [workspace.dependencies]
-actix-prost = { version = "0.2.0", path = "actix-prost" }
-actix-prost-build = { version = "0.2.0", path = "actix-prost-build" }
-actix-prost-macros = { version = "0.2.0", path = "actix-prost-macros" }
-convert-trait = { version = "0.2.0", path = "actix-prost-convert-trait", package = "actix-prost-convert-trait" }
+actix-prost = { path = "actix-prost" }
+actix-prost-build = { path = "actix-prost-build" }
+actix-prost-macros = { path = "actix-prost-macros" }
+convert-trait = { path = "actix-prost-convert-trait", package = "actix-prost-convert-trait" }
 
 actix-http = { version = "3" }
 actix-web = { version = "4" }

--- a/actix-prost-convert-trait/src/datetime.rs
+++ b/actix-prost-convert-trait/src/datetime.rs
@@ -1,5 +1,15 @@
-use crate::{impl_try_convert_to_string, TryConvert};
+use crate::TryConvert;
 use chrono::{DateTime, FixedOffset, NaiveDateTime, Utc};
+
+macro_rules! impl_try_convert_datetime_to_string {
+    ($type:ty) => {
+        impl TryConvert<$type> for String {
+            fn try_convert(value: $type) -> Result<Self, String> {
+                Ok(value.to_rfc3339())
+            }
+        }
+    };
+}
 
 // DateTime<Utc> conversions
 impl TryConvert<String> for DateTime<Utc> {
@@ -20,7 +30,7 @@ impl TryConvert<String> for DateTime<Utc> {
     }
 }
 
-impl_try_convert_to_string!(DateTime<Utc>);
+impl_try_convert_datetime_to_string!(DateTime<Utc>);
 
 // DateTime<FixedOffset> conversions
 impl TryConvert<String> for DateTime<FixedOffset> {
@@ -46,7 +56,7 @@ impl TryConvert<String> for DateTime<FixedOffset> {
     }
 }
 
-impl_try_convert_to_string!(DateTime<FixedOffset>);
+impl_try_convert_datetime_to_string!(DateTime<FixedOffset>);
 
 // NaiveDateTime conversions
 impl TryConvert<String> for NaiveDateTime {
@@ -68,7 +78,11 @@ impl TryConvert<String> for NaiveDateTime {
     }
 }
 
-impl_try_convert_to_string!(NaiveDateTime);
+impl TryConvert<NaiveDateTime> for String {
+    fn try_convert(value: NaiveDateTime) -> Result<Self, String> {
+        Ok(value.format("%Y-%m-%dT%H:%M:%S").to_string())
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -76,7 +90,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn test_conversion_datetime() {
+    fn test_conversion_datetime_from_string() {
         let datetime = DateTime::<Utc>::try_convert("1645491600".to_string()).unwrap();
         assert_eq!(
             datetime,
@@ -151,7 +165,10 @@ mod tests {
             datetime,
             "2021-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap()
         );
+    }
 
+    #[test]
+    fn test_conversion_datetime_errors() {
         // Error cases
         let error = DateTime::<Utc>::try_convert("2021-01-01T00:00:00".to_string())
             .expect_err("Invalid datetime");
@@ -176,5 +193,24 @@ mod tests {
             error,
             "failed to parse '' as NaiveDateTime: premature end of input"
         );
+    }
+
+    #[test]
+    fn test_conversion_datetime_to_string() {
+        let datetime = "2021-01-01T00:00:00+00:00"
+            .parse::<DateTime<Utc>>()
+            .unwrap();
+        let string = String::try_convert(datetime).unwrap();
+        assert_eq!(string, "2021-01-01T00:00:00+00:00");
+
+        let datetime = "2021-01-01T00:00:00+00:00"
+            .parse::<DateTime<FixedOffset>>()
+            .unwrap();
+        let string = String::try_convert(datetime).unwrap();
+        assert_eq!(string, "2021-01-01T00:00:00+00:00");
+
+        let datetime = "2021-01-01T00:00:00".parse::<NaiveDateTime>().unwrap();
+        let string = String::try_convert(datetime).unwrap();
+        assert_eq!(string, "2021-01-01T00:00:00");
     }
 }

--- a/actix-prost-convert-trait/src/datetime.rs
+++ b/actix-prost-convert-trait/src/datetime.rs
@@ -78,9 +78,13 @@ impl TryConvert<String> for NaiveDateTime {
     }
 }
 
+
+// implemented via Debug according to the implementation of the serde module
+// https://github.com/chronotope/chrono/blob/e632ffd3b89d3cfaa96776f2368ee4c21a972766/src/naive/datetime/serde.rs#L6-L26
+// https://docs.rs/chrono/latest/chrono/naive/struct.NaiveDateTime.html#impl-Debug-for-NaiveDateTime
 impl TryConvert<NaiveDateTime> for String {
     fn try_convert(value: NaiveDateTime) -> Result<Self, String> {
-        Ok(value.format("%Y-%m-%dT%H:%M:%S").to_string())
+        Ok(format!("{:?}", value))
     }
 }
 
@@ -197,20 +201,20 @@ mod tests {
 
     #[test]
     fn test_conversion_datetime_to_string() {
-        let datetime = "2021-01-01T00:00:00+00:00"
+        let datetime = "2021-01-01T00:00:00.123456789+00:00"
             .parse::<DateTime<Utc>>()
             .unwrap();
         let string = String::try_convert(datetime).unwrap();
-        assert_eq!(string, "2021-01-01T00:00:00+00:00");
+        assert_eq!(string, "2021-01-01T00:00:00.123456789+00:00");
 
-        let datetime = "2021-01-01T00:00:00+00:00"
+        let datetime = "2021-01-01T00:00:00.123456789+00:00"
             .parse::<DateTime<FixedOffset>>()
             .unwrap();
         let string = String::try_convert(datetime).unwrap();
-        assert_eq!(string, "2021-01-01T00:00:00+00:00");
+        assert_eq!(string, "2021-01-01T00:00:00.123456789+00:00");
 
-        let datetime = "2021-01-01T00:00:00".parse::<NaiveDateTime>().unwrap();
+        let datetime = "2021-01-01T00:00:00.123456789".parse::<NaiveDateTime>().unwrap();
         let string = String::try_convert(datetime).unwrap();
-        assert_eq!(string, "2021-01-01T00:00:00");
+        assert_eq!(string, "2021-01-01T00:00:00.123456789");
     }
 }

--- a/tests/proto/conversions.proto
+++ b/tests/proto/conversions.proto
@@ -91,8 +91,10 @@ message ConversionsResponse {
   
   // Response fields with conversions
   string response_utc_datetime = 5 [ (convert_options.convert) = { type : "chrono::DateTime<chrono::Utc>" } ];
-  string response_uuid = 6 [ (convert_options.convert) = { type : "uuid::Uuid" } ];
-  string response_decimal = 7 [ (convert_options.convert) = { type : "rust_decimal::Decimal" } ];
+  string response_fixed_offset_datetime = 7 [ (convert_options.convert) = { type : "chrono::DateTime<chrono::FixedOffset>" } ];
+  string response_naive_datetime = 8 [ (convert_options.convert) = { type : "chrono::NaiveDateTime" } ];
+  string response_uuid = 9 [ (convert_options.convert) = { type : "uuid::Uuid" } ];
+  string response_decimal = 10 [ (convert_options.convert) = { type : "rust_decimal::Decimal" } ];
 }
 
 

--- a/tests/src/conversions.rs
+++ b/tests/src/conversions.rs
@@ -35,6 +35,8 @@ impl ConversionsRpc for ConversionsServer {
             map_field: internal_request.map_field,
             config: None,
             response_utc_datetime: internal_request.utc_datetime,
+            response_fixed_offset_datetime: internal_request.fixed_offset_datetime,
+            response_naive_datetime: internal_request.naive_datetime,
             response_uuid: internal_request.uuid_field,
             response_decimal: internal_request.decimal_field,
         };
@@ -189,6 +191,12 @@ async fn conversions() {
     assert_eq!(status, StatusCode::OK, "error: {res}");
     let res: ConversionsResponse = serde_json::from_str(&res).unwrap();
     assert_eq!(res.nested.unwrap().address, test_address);
+    assert_eq!(res.response_utc_datetime, "2023-01-01T00:00:00+00:00");
+    assert_eq!(
+        res.response_fixed_offset_datetime,
+        "2023-01-01T00:00:00+01:00"
+    );
+    assert_eq!(res.response_naive_datetime, "2023-01-01T00:00:00");
 }
 
 #[test]

--- a/tests/src/proto/conversions.rs
+++ b/tests/src/proto/conversions.rs
@@ -113,9 +113,13 @@ pub struct ConversionsResponse {
     /// Response fields with conversions
     #[prost(string, tag = "5")]
     pub response_utc_datetime: ::prost::alloc::string::String,
-    #[prost(string, tag = "6")]
-    pub response_uuid: ::prost::alloc::string::String,
     #[prost(string, tag = "7")]
+    pub response_fixed_offset_datetime: ::prost::alloc::string::String,
+    #[prost(string, tag = "8")]
+    pub response_naive_datetime: ::prost::alloc::string::String,
+    #[prost(string, tag = "9")]
+    pub response_uuid: ::prost::alloc::string::String,
+    #[prost(string, tag = "10")]
     pub response_decimal: ::prost::alloc::string::String,
 }
 #[actix_prost_macros::serde]
@@ -401,6 +405,8 @@ pub struct ConversionsResponseInternal {
     >,
     pub config: ::core::option::Option<ConfigInternal>,
     pub response_utc_datetime: chrono::DateTime<chrono::Utc>,
+    pub response_fixed_offset_datetime: chrono::DateTime<chrono::FixedOffset>,
+    pub response_naive_datetime: chrono::NaiveDateTime,
     pub response_uuid: uuid::Uuid,
     pub response_decimal: rust_decimal::Decimal,
 }
@@ -413,6 +419,12 @@ impl convert_trait::TryConvert<ConversionsResponseInternal> for ConversionsRespo
             config: convert_trait::TryConvert::try_convert(from.config)?,
             response_utc_datetime: convert_trait::TryConvert::try_convert(
                 from.response_utc_datetime,
+            )?,
+            response_fixed_offset_datetime: convert_trait::TryConvert::try_convert(
+                from.response_fixed_offset_datetime,
+            )?,
+            response_naive_datetime: convert_trait::TryConvert::try_convert(
+                from.response_naive_datetime,
             )?,
             response_uuid: convert_trait::TryConvert::try_convert(from.response_uuid)?,
             response_decimal: convert_trait::TryConvert::try_convert(


### PR DESCRIPTION
Change conversion from Datetime to String

Now it uses to_rfc3339() and now it's compatible with ISO 8601