### PR TITLE
fix: preserve all headers from response metadata

### DIFF
--- a/actix-prost-build/src/method.rs
+++ b/actix-prost-build/src/method.rs
@@ -78,7 +78,7 @@ impl Method {
                 #response_convert
                 let mut json_response = ::actix_web::web::Json(response).customize();
                 for (key, value) in headers.iter() {
-                    json_response = json_response.insert_header((key.as_str(), value.as_bytes()));
+                    json_response = json_response.append_header((key.as_str(), value.as_bytes()));
                 }
                 Ok(json_response)
             }

--- a/tests/src/proto/conversions.rs
+++ b/tests/src/proto/conversions.rs
@@ -565,7 +565,7 @@ pub mod conversions_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }

--- a/tests/src/proto/errors.rs
+++ b/tests/src/proto/errors.rs
@@ -369,7 +369,7 @@ pub mod errors_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }

--- a/tests/src/proto/rest.rs
+++ b/tests/src/proto/rest.rs
@@ -969,7 +969,7 @@ pub mod rest_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }
@@ -1006,7 +1006,7 @@ pub mod rest_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }
@@ -1046,7 +1046,7 @@ pub mod rest_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }
@@ -1095,7 +1095,7 @@ pub mod rest_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }
@@ -1126,7 +1126,7 @@ pub mod rest_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }
@@ -1157,7 +1157,7 @@ pub mod rest_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }
@@ -1186,7 +1186,7 @@ pub mod rest_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }
@@ -1218,7 +1218,7 @@ pub mod rest_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }
@@ -1250,7 +1250,7 @@ pub mod rest_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }

--- a/tests/src/proto/serde_overrides.rs
+++ b/tests/src/proto/serde_overrides.rs
@@ -699,7 +699,7 @@ pub mod serde_overrides_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }
@@ -728,7 +728,7 @@ pub mod serde_overrides_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }
@@ -757,7 +757,7 @@ pub mod serde_overrides_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }
@@ -788,7 +788,7 @@ pub mod serde_overrides_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }

--- a/tests/src/proto/simple.rs
+++ b/tests/src/proto/simple.rs
@@ -366,7 +366,7 @@ pub mod simple_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }

--- a/tests/src/proto/snake_case_types.rs
+++ b/tests/src/proto/snake_case_types.rs
@@ -442,7 +442,7 @@ pub mod snake_case_types_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }
@@ -471,7 +471,7 @@ pub mod snake_case_types_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }

--- a/tests/src/proto/types.rs
+++ b/tests/src/proto/types.rs
@@ -901,7 +901,7 @@ pub mod types_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }
@@ -934,7 +934,7 @@ pub mod types_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }
@@ -961,7 +961,7 @@ pub mod types_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }
@@ -988,7 +988,7 @@ pub mod types_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }
@@ -1015,7 +1015,7 @@ pub mod types_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }
@@ -1042,7 +1042,7 @@ pub mod types_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }
@@ -1075,7 +1075,7 @@ pub mod types_rpc_actix {
         let mut json_response = ::actix_web::web::Json(response).customize();
         for (key, value) in headers.iter() {
             json_response = json_response
-                .insert_header((key.as_str(), value.as_bytes()));
+                .append_header((key.as_str(), value.as_bytes()));
         }
         Ok(json_response)
     }


### PR DESCRIPTION
## Problem
When forwarding headers from gRPC response metadata to HTTP response, 
`insert_header` was being used which overwrites any existing header 
with the same name. This causes data loss when the metadata contains 
multiple headers with the same key.

## Solution
Changed from `insert_header` to `append_header` to preserve all headers 
from gRPC metadata exactly as they are, without overwriting duplicates.

## Example
Headers like `Set-Cookie`, `Link`, `Warning`, or any custom headers that 
may appear multiple times are now correctly forwarded to the HTTP response.